### PR TITLE
Add a config to output object position in logs

### DIFF
--- a/Splatoon/Gui/CGuiGeneralSettings.cs
+++ b/Splatoon/Gui/CGuiGeneralSettings.cs
@@ -63,6 +63,9 @@ partial class CGui
             Logger.OnTerritoryChanged();
         }
         ImGuiComponents.HelpMarker("Enable logging, which will log chat messages, casts and VFX info into log files. ".Loc());
+        ImGui.SameLine();
+        ImGui.Checkbox("Log position".Loc(), ref P.Config.LogPosition);
+        ImGuiComponents.HelpMarker("Log object position in casting information log lines".Loc());
 
         ImGui.Separator();
         ImGuiEx.TextV("Splatoon language: ".Loc());

--- a/Splatoon/Memory/AttachedInfo.cs
+++ b/Splatoon/Memory/AttachedInfo.cs
@@ -134,7 +134,15 @@ public unsafe static class AttachedInfo
                     {
                         CastInfos[b.Address] = new(b.CastActionId, Environment.TickCount64 - (long)(b.CurrentCastTime * 1000));
                         Casters.Add(b.Address);
-                        var text = $"{b.Name} starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
+                        string text;
+                        if (P.Config.LogPosition)
+                        {
+                            text = $"{b.Name} ({x.Position.ToString()}) starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
+                        }
+                        else
+                        {
+                            text = $"{b.Name} starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
+                        }
                         P.ChatMessageQueue.Enqueue(text);
                         if (P.Config.Logging)
                         {

--- a/Splatoon/Serializables/Configuration.cs
+++ b/Splatoon/Serializables/Configuration.cs
@@ -47,6 +47,7 @@ class Configuration : IPluginConfiguration
     public bool FocusMode = false;
     public bool NoStreamWarning = false;
     public bool Logging = false;
+    public bool LogPosition = false;
 
     public string PluginLanguage = null;
     public bool NoFindReset = false;


### PR DESCRIPTION
Add a config to output object position in the casting information log lines.