### PR TITLE
Modify response header in Web API to allow for CORS capabilities.

### DIFF
--- a/Splatoon/Modules/HTTPServer.cs
+++ b/Splatoon/Modules/HTTPServer.cs
@@ -159,7 +159,8 @@ class HTTPServer : IDisposable
                         status.Add(e.StackTrace);
                     }
                     HttpListenerResponse response = context.Response;
-                    response.AppendHeader("Access-Control-Allow-Origin", "*");
+                    response.AppendHeader("Access-Control-Allow-Origin", request.Headers["Origin"]);
+                    response.AppendHeader("Access-Control-Allow-Headers", "Content-Type");
                     string responseString = string.Join("\n", status);
                     byte[] buffer = Encoding.UTF8.GetBytes(responseString);
                     response.ContentLength64 = buffer.Length;


### PR DESCRIPTION
Modify the response header of the Splatoon Web API by adjusting the `Access-Control-Allow-Origin` and `Access-Control-Allow-Methods` fields, thus allowing CORS. This is necessary as the CORS policy is currently blocking access to the Web API via a Chromium client.