### PR TITLE
Ignore errors caused by invalid BattleChara in cutscenes

### DIFF
--- a/Splatoon/Memory/AttachedInfo.cs
+++ b/Splatoon/Memory/AttachedInfo.cs
@@ -127,9 +127,17 @@ public unsafe static class AttachedInfo
     {
         foreach(var x in Svc.Objects)
         {
-            if(x is BattleChara b)
-            {
-                if (b.IsCasting)
+            if(x is BattleChara b) {
+                bool isCasting;
+                try {
+                    isCasting = b.IsCasting;
+                }
+                catch {
+                    // Ignore invalid BattleChara objects that exist during cutscenes
+                    continue;
+                }
+
+                if (isCasting)
                 {
                     if (!Casters.Contains(b.Address)) 
                     {


### PR DESCRIPTION
When viewing most cutscenes, certain "invalid" `BattleChara`s exist in the object table. These `BattleChara`s don't have valid casting info, so when we try to get that info in `Splatoon.Memory.AttachedInfo.Tick`, it causes a lot of spam in the Dalamud log like so:

```
ERR Exception while dispatching Framework::Update event.
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Splatoon.Memory.AttachedInfo.Tick(Object _) in C:\VS\Splatoon\Splatoon\Memory\AttachedInfo.cs:line 131
   at InvokeStub_AttachedInfo.Tick(Object, Object, IntPtr*)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Dalamud.Game.Framework.HandleFrameworkUpdate(IntPtr framework) in C:\goatsoft\companysecrets\dalamud\Game\Framework.cs:line 487
```

This should be reproducible easily by viewing any cutscene in The Unending Journey at an inn.

This change simply silences these errors by ignoring the exception.

One alternative would be to check for the null pointer with e.g.
```csharp
var isInvalidBattleChara = (nint)((FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara*)b.Address)->GetCastInfo == 0;
```
but this seemed more cumbersome and more expensive in the most common case (outside of a cutscene).