### PR TITLE
Fix loading spam message in log

### DIFF
--- a/Splatoon/Modules/Loader.cs
+++ b/Splatoon/Modules/Loader.cs
@@ -124,7 +124,7 @@ internal class Loader
     void Load(IFramework fr)
     {
         PluginLog.Information("Splatoon begins loading process");
-        fr.Update -= Load;
+        Svc.Framework.Update -= Load;
         p.Load(Svc.PluginInterface);
         PluginLog.Information("Splatoon has been loaded");
     }


### PR DESCRIPTION
Correctly removes the load event from the correct framework object, preventing log spam where it loops over and over infinitely.