### PR TITLE
Fix reset behaviour

### DIFF
--- a/SplatoonScripts/Duties/Endwalker/DSR Towers.cs
+++ b/SplatoonScripts/Duties/Endwalker/DSR Towers.cs
@@ -258,6 +258,7 @@ namespace SplatoonScriptsOfficial.Duties.Endwalker
         void Off()
         {
             SolutionElement.Enabled = false;
+            takeMeteorTower = false;
             foreach(var e in TowerElements)
             {
                 e.Enabled = false;


### PR DESCRIPTION
This fixes the take/don't take tower marker, after having meteor the first time it will otherwise always tell you to get the meteor tower.