### PR TITLE
Add new default fill coloring system

### DIFF
--- a/Splatoon/Gui/CGuiGeneralSettings.cs
+++ b/Splatoon/Gui/CGuiGeneralSettings.cs
@@ -105,16 +105,15 @@ partial class CGui
         if (ImGui.CollapsingHeader("Global Style Overrides"))
         {
             ImGui.Indent();
-            SImGuiEx.SizedText("Minimum Fill Alpha", CGui.WidthElement);
+            SImGuiEx.SizedText("Minimum Fill Alpha:", CGui.WidthElement);
             ImGui.SameLine();
             ImGui.SetNextItemWidth(200f);
-            ImGui.DragInt("##minfillalpha", ref P.Config.MinFillAlpha, 1, 0, P.Config.MaxFillAlpha);
+            ImGui.SliderInt("##minfillalpha", ref P.Config.MinFillAlpha, 0, P.Config.MaxFillAlpha);
 
-            SImGuiEx.SizedText("Maximum Fill Alpha", CGui.WidthElement);
+            SImGuiEx.SizedText("Maximum Fill Alpha:", CGui.WidthElement);
             ImGui.SameLine();
             ImGui.SetNextItemWidth(200f);
-            ImGui.DragInt("##maxfillalpha", ref P.Config.MaxFillAlpha, 1, P.Config.MinFillAlpha, 255);
-            
+            ImGui.SliderInt("##maxfillalpha", ref P.Config.MaxFillAlpha, P.Config.MinFillAlpha, 255);
             // If min == max, users can break ints out of min and max values in the UI. Clamp to sane values for safety.
             P.Config.MinFillAlpha = Math.Clamp(P.Config.MinFillAlpha, 0, P.Config.MaxFillAlpha);
             P.Config.MaxFillAlpha = Math.Clamp(P.Config.MaxFillAlpha, P.Config.MinFillAlpha, 255);

--- a/Splatoon/Serializables/DisplayStyle.cs
+++ b/Splatoon/Serializables/DisplayStyle.cs
@@ -7,27 +7,5 @@
         public uint originFillColor = originFillColor;
         public uint endFillColor = endFillColor;
         public bool filled = filled;
-
-        public uint fillColor(float amount)
-        {
-            return Lerp(originFillColor, endFillColor, amount);
-        }
-
-        public uint animatedOriginFillColor(float animatePercent)
-        {
-            if (animatePercent < 0.5)
-            {
-                return Lerp(originFillColor, endFillColor, animatePercent / 0.5f);
-            }
-            return endFillColor;
-        }
-        public uint animatedEndFillColor(float animatePercent)
-        {
-            if (animatePercent > 0.5)
-            {
-                return Lerp(originFillColor, endFillColor, (animatePercent - 0.5f) / 0.5f);
-            }
-            return originFillColor;
-        }
     }
 }

--- a/Splatoon/Serializables/DisplayStyle.cs
+++ b/Splatoon/Serializables/DisplayStyle.cs
@@ -1,11 +1,20 @@
 ﻿namespace Splatoon.Serializables
 {
-    public struct DisplayStyle(uint strokeColor, float strokeThickness, uint originFillColor, uint endFillColor, bool filled = true)
+    public struct DisplayStyle(
+        uint strokeColor,
+        float strokeThickness,
+        float fillIntensity,
+        uint originFillColor,
+        uint endFillColor,
+        bool filled = true,
+        bool overrideFillColor = false)
     {
         public uint strokeColor = strokeColor;
         public float strokeThickness = strokeThickness;
+        public float fillIntensity = fillIntensity;
         public uint originFillColor = originFillColor;
         public uint endFillColor = endFillColor;
         public bool filled = filled;
+        public bool overrideFillColor = overrideFillColor;
     }
 }

--- a/Splatoon/Serializables/MechanicType.cs
+++ b/Splatoon/Serializables/MechanicType.cs
@@ -43,12 +43,12 @@ public static class MechanicTypes {
 
     public static readonly Dictionary<MechanicType, DisplayStyle> DefaultMechanicColors = new()
     {
-         { MechanicType.Unspecified, new(0xC8006FFF, 2f, 0x45006FFF, 0x45006FFF) },
-         { MechanicType.Danger, new(0xC80000FF, 2f, 0x450000FF, 0x450000FF) },
-         { MechanicType.Safe, new(0xC800D114, 2f, 0x4500D114, 0x4500D114) },
-         { MechanicType.Soak, new(0xC8FF9000, 2f, 0x45FF9000, 0x45FF9000) },
-         { MechanicType.Gaze, new(0xC8A000D6, 2f, 0x45A000D6, 0x45A000D6) },
-         { MechanicType.Knockback, new(0xC800F7FF, 2f, 0x4500F7FF, 0x4500F7FF) },
+         { MechanicType.Unspecified, new(0xC8006FFF, 2f, 0.3f, 0x45006FFF, 0x45006FFF) },
+         { MechanicType.Danger, new(0xC80000FF, 2f, 0.3f, 0x450000FF, 0x450000FF) },
+         { MechanicType.Safe, new(0xC800D114, 2f, 0.3f, 0x4500D114, 0x4500D114) },
+         { MechanicType.Soak, new(0xC8FF9000, 2f, 0.3f, 0x45FF9000, 0x45FF9000) },
+         { MechanicType.Gaze, new(0xC8A000D6, 2f, 0.3f, 0x45A000D6, 0x45A000D6) },
+         { MechanicType.Knockback, new(0xC800F7FF, 2f, 0.3f, 0x4500F7FF, 0x4500F7FF) },
     };
 
     public static bool CanOverride(MechanicType type)

--- a/Splatoon/Structures/DisplayObjectInterfaces.cs
+++ b/Splatoon/Structures/DisplayObjectInterfaces.cs
@@ -70,7 +70,7 @@ public class DisplayObjectLine : DisplayObject
         this.start = new Vector3(ax, az, ay);
         this.stop = new Vector3(bx, bz, by);
         this.radius = 0;
-        this.style = new DisplayStyle(color, thickness, 0, 0);
+        this.style = new DisplayStyle(color, thickness, 0f, 0, 0);
     }
     public Vector3 Direction
     {

--- a/Splatoon/Utils/Colors.cs
+++ b/Splatoon/Utils/Colors.cs
@@ -10,4 +10,12 @@ public static class Colors
     public const uint Transparent = 0x00000000;
     public const uint Green = 0xff00ff00;
     public const uint Yellow = 0xff00ffff;
+
+    public static uint MultiplyAlpha(uint color, float amount)
+    {
+        uint alpha = color >> 24;
+        alpha = (uint)(alpha * amount);
+        alpha = Math.Clamp(alpha, 0x00, 0xFF);
+        return color & 0x00FFFFFF | (alpha << 24);
+    }
 }

--- a/Splatoon/Utils/SImGuiEx.cs
+++ b/Splatoon/Utils/SImGuiEx.cs
@@ -159,24 +159,48 @@ public static class SImGuiEx //came here to laugh on how scuffed it is? let's do
         {
             edited = true;
         }
-        ImGui.SameLine();
-        ImGuiEx.Text("Origin:".Loc());
-        ImGui.SameLine();
-        v4 = ImGui.ColorConvertU32ToFloat4(style.originFillColor);
-        if (ImGui.ColorEdit4("##fillorigincolorbutton" + name, ref v4, ImGuiColorEditFlags.NoInputs))
+        if (!style.filled) ImGui.BeginDisabled();
         {
-            style.originFillColor = ImGui.ColorConvertFloat4ToU32(v4);
-            edited = true;
+            ImGui.SameLine();
+            if (style.overrideFillColor) ImGui.BeginDisabled();
+            ImGuiEx.Text("Intensity:".Loc());
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(200f);
+            if (ImGui.SliderFloat("##fillintensity" + name, ref style.fillIntensity, 0f, 1f))
+            {
+                edited = true;
+            }
+            if (style.overrideFillColor) ImGui.EndDisabled();
+            ImGui.Indent(CGui.WidthElement + 15f);
+            {
+                if (ImGui.Checkbox("Override Colors".Loc() + "##name" + name, ref style.overrideFillColor))
+                {
+                    edited = true;
+                }
+                if (!style.overrideFillColor) ImGui.BeginDisabled();
+                ImGui.SameLine();
+                ImGuiEx.Text("Origin:".Loc());
+                ImGui.SameLine();
+                v4 = ImGui.ColorConvertU32ToFloat4(style.originFillColor);
+                if (ImGui.ColorEdit4("##fillorigincolorbutton" + name, ref v4, ImGuiColorEditFlags.NoInputs))
+                {
+                    style.originFillColor = ImGui.ColorConvertFloat4ToU32(v4);
+                    edited = true;
+                }
+                ImGui.SameLine();
+                ImGuiEx.Text("End:".Loc());
+                ImGui.SameLine();
+                v4 = ImGui.ColorConvertU32ToFloat4(style.endFillColor);
+                if (ImGui.ColorEdit4("##fillendcolorbutton" + name, ref v4, ImGuiColorEditFlags.NoInputs))
+                {
+                    style.endFillColor = ImGui.ColorConvertFloat4ToU32(v4);
+                    edited = true;
+                }
+                if (!style.overrideFillColor) ImGui.EndDisabled();
+            }
+            ImGui.Unindent(CGui.WidthElement + 15f);
         }
-        ImGui.SameLine();
-        ImGuiEx.Text("End:".Loc());
-        ImGui.SameLine();
-        v4 = ImGui.ColorConvertU32ToFloat4(style.endFillColor);
-        if (ImGui.ColorEdit4("##fillendcolorbutton" + name, ref v4, ImGuiColorEditFlags.NoInputs))
-        {
-            style.endFillColor = ImGui.ColorConvertFloat4ToU32(v4);
-            edited = true;
-        }
+        if (!style.filled) ImGui.EndDisabled();
         return edited;
     }
 }

--- a/Splatoon/Utils/Static.cs
+++ b/Splatoon/Utils/Static.cs
@@ -525,14 +525,6 @@ public static unsafe class Static
         return A + Vector3.Multiply(D, d);
     }
 
-    // Linear interpolation between 1-byte components of uint32
-    // Intended for interpolating colors
-    public static uint Lerp(uint v1, uint v2, float amount)
-    {
-        if (v1 == v2) return v1;
-        return Vector4.Lerp(v1.ToVector4(), v2.ToVector4(), amount).ToUint();
-    }
-
     public static float DegreesToRadians(this int val)
     {
         return (float)(Math.PI / 180f * val);


### PR DESCRIPTION
By default, fill will use the stroke color with its alpha multiplied by some intensity.
Fill colors can now only be chosen directly with an override flag.