### PR TITLE
added drawing of filled cone for element.type==5

### DIFF
--- a/Splatoon/Gui/CGuiGeneralSettings.cs
+++ b/Splatoon/Gui/CGuiGeneralSettings.cs
@@ -156,9 +156,11 @@ partial class CGui
             P.Config.AltRectStep = def.AltRectStep;
             P.Config.AltRectStepOverride = def.AltRectStepOverride;
         }
+
+        ImGui.Checkbox("Fill cones".Loc(), ref p.Config.FillCone);
+
         ImGui.Checkbox("Use line rectangle filling".Loc(), ref p.Config.AltRectFill);
         ImGuiComponents.HelpMarker("Fill rectangles with stroke instead of full color. This will remove clipping issues, but may feel more disturbing.".Loc());
-        
 
         ImGui.SetNextItemWidth(60f);
         ImGui.DragFloat("Minimal rectangle fill line interval".Loc(), ref p.Config.AltRectStep, 0.001f, 0, float.MaxValue);

--- a/Splatoon/Gui/OverlayGui.cs
+++ b/Splatoon/Gui/OverlayGui.cs
@@ -174,69 +174,6 @@ unsafe class OverlayGui : IDisposable
         }
     }
 
-    // not working
-    // https://stackoverflow.com/questions/47846087/how-to-fill-the-area-between-two-bezier-curves-using-dear-imgui
-    void AltDrawDonutWorld(DisplayObjectDonut e)
-    {
-        var drawList = ImGui.GetWindowDrawList();
-        (e.y, e.z) = (e.z, e.y);
-
-        Vector2 v;
-        Svc.GameGui.WorldToScreen(new Vector3(e.x + e.radius, e.y, e.z), out v);
-        drawList.PathLineTo(v);
-
-        for (float i = 0; i < MathF.PI; i += MathF.PI / 2)
-        {
-            float theta = MathF.PI / 2; 
-            float h = 1.3f * (1 - MathF.Cos(theta / 2)) / MathF.Sin(theta / 2);
-
-            Vector3 arcMid1 = new Vector3(
-                e.x + e.radius * (MathF.Cos(i) - h * MathF.Sin(i)),
-                e.y,
-                e.z + e.radius * (MathF.Sin(i) + h * MathF.Cos(i)));
-            Vector3 arcMid2 = new Vector3(
-                e.x + e.radius * (MathF.Cos(i + theta) + h * MathF.Sin(i + theta)),
-                e.y,
-                e.z + e.radius * (MathF.Sin(i + theta) - h * MathF.Cos(i + theta)));
-            Vector3 endPoint = new Vector3(
-                e.x + e.radius * MathF.Cos(i + theta), e.y, e.z + e.radius * MathF.Sin(i + theta));
-
-            Svc.GameGui.WorldToScreen(arcMid1, out Vector2 v1);
-            Svc.GameGui.WorldToScreen(arcMid2, out Vector2 v2);
-            Svc.GameGui.WorldToScreen(endPoint, out v);
-            drawList.PathBezierCubicCurveTo(v1, v2, v);
-        }
-
-        Svc.GameGui.WorldToScreen(new Vector3(e.x - e.donut, e.y, e.z), out v);
-        drawList.PathLineTo(v);
-
-        for (float i = MathF.PI; i > 0; i -= MathF.PI / 2)
-        {
-            float theta = MathF.PI / 2;
-            float h = 1.3f * (1 - MathF.Cos(theta / 2)) / MathF.Sin(theta / 2);
-
-            Vector3 arcMid1 = new Vector3(
-                e.x + e.donut * (MathF.Cos(i - theta) - h * MathF.Sin(i - theta)),
-                e.y,
-                e.z + e.donut * (MathF.Sin(i - theta) + h * MathF.Cos(i - theta)));
-            Vector3 arcMid2 = new Vector3(
-                e.x + e.donut * (MathF.Cos(i) + h * MathF.Sin(i)),
-                e.y,
-                e.z + e.donut * (MathF.Sin(i) - h * MathF.Cos(i)));
-            Vector3 endPoint = new Vector3(
-                e.x + e.donut * MathF.Cos(i - theta), e.y, e.z + e.donut * MathF.Sin(i - theta));
-
-            Svc.GameGui.WorldToScreen(arcMid1, out Vector2 v1);
-            Svc.GameGui.WorldToScreen(arcMid2, out Vector2 v2);
-            Svc.GameGui.WorldToScreen(endPoint, out v);
-            drawList.PathBezierCubicCurveTo(v2, v1, v);
-        }
-
-        Svc.GameGui.WorldToScreen(new Vector3(e.x + e.radius, e.y, e.z), out v);
-        drawList.PathLineTo(v);
-        drawList.PathFillConvex(e.color); 
-    }
-
     void DrawLineWorld(DisplayObjectLine e)
     {
         if (p.Profiler.Enabled) p.Profiler.GuiLines.StartTick();

--- a/Splatoon/Serializables/Configuration.cs
+++ b/Splatoon/Serializables/Configuration.cs
@@ -45,6 +45,8 @@ class Configuration : IPluginConfiguration
     public bool AltConeStepOverride = false;
     public int AltConeStep = 1;
 
+    public bool FillCone = true; 
+
     public bool FocusMode = false;
     public bool NoStreamWarning = false;
     public bool Logging = false;

--- a/Splatoon/Splatoon.cs
+++ b/Splatoon/Splatoon.cs
@@ -909,24 +909,32 @@ public unsafe class Splatoon : IDalamudPlugin
             if (e.coneAngleMax > e.coneAngleMin)
             {
                 var pos = new Vector3(e.refX + e.offX, e.refY + e.offY, e.refZ + e.offZ);
-                for (var x = e.coneAngleMin; x < e.coneAngleMax; x += GetFillStepCone(e.FillStep))
-                {
-                    var angle = e.FaceMe ?
-                        (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()) - x.Float())).DegreesToRadians()
-                        : (-x.Float()).DegreesToRadians();
-                    var baseAngle = e.FaceMe ?
+                var baseAngle = e.FaceMe ?
                         (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()))).DegreesToRadians()
                         : 0;
-                    AddConeLine(pos, baseAngle, angle, e, e.radius);
+
+                if (Config.FillCone)
+                {
+                    baseAngle = -baseAngle + MathF.PI; 
+                    var startRad = baseAngle + e.coneAngleMin.Float().DegreesToRadians() - MathF.PI / 2;
+                    var endRad = baseAngle + e.coneAngleMax.Float().DegreesToRadians() - MathF.PI / 2;
+                    AddCone(pos, startRad, endRad, e, e.radius); 
                 }
+                else
                 {
-                    var angle = e.FaceMe ?
-                        (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()) - e.coneAngleMax.Float())).DegreesToRadians()
-                        : (-e.coneAngleMax.Float()).DegreesToRadians();
-                    var baseAngle = e.FaceMe ?
-                        (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()))).DegreesToRadians()
-                        : 0;
-                    AddConeLine(pos, baseAngle, angle, e, e.radius);
+                    for (var x = e.coneAngleMin; x < e.coneAngleMax; x += GetFillStepCone(e.FillStep))
+                    {
+                        var angle = e.FaceMe ?
+                            (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()) - x.Float())).DegreesToRadians()
+                            : (-x.Float()).DegreesToRadians();
+                        AddConeLine(pos, baseAngle, angle, e, e.radius);
+                    }
+                    {
+                        var angle = e.FaceMe ?
+                            (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()) - e.coneAngleMax.Float())).DegreesToRadians()
+                            : (-e.coneAngleMax.Float()).DegreesToRadians();
+                        AddConeLine(pos, baseAngle, angle, e, e.radius);
+                    }
                 }
             }
         }
@@ -1229,6 +1237,15 @@ public unsafe class Splatoon : IDalamudPlugin
             }
             displayObjects.Add(new DisplayObjectText(cx, cy, z + e.offZ + e.overlayVOffset, text, e.overlayBGColor, e.overlayTextColor, e.overlayFScale));
         }
+    }
+
+    void AddCone(Vector3 center, float startRad, float endRad, Element e, float radius)
+    {
+        //PluginLog.Debug($"[addcone] {center}, {startRad} -> {endRad}"); 
+        displayObjects.Add(new DisplayObjectCone(
+            center.X, center.Y, center.Z, radius, startRad, endRad,
+            e.thicc, e.color, true
+            )); 
     }
 
     void AddConeLine(Vector3 tPos, float baseAngle, float angle, Element e, float radius)

--- a/Splatoon/Splatoon.cs
+++ b/Splatoon/Splatoon.cs
@@ -909,15 +909,12 @@ public unsafe class Splatoon : IDalamudPlugin
             if (e.coneAngleMax > e.coneAngleMin)
             {
                 var pos = new Vector3(e.refX + e.offX, e.refY + e.offY, e.refZ + e.offZ);
-                var baseAngle = e.FaceMe ?
-                        (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()))).DegreesToRadians()
-                        : 0;
 
                 if (Config.FillCone)
                 {
-                    baseAngle = -baseAngle + MathF.PI; 
-                    var startRad = baseAngle + e.coneAngleMin.Float().DegreesToRadians() - MathF.PI / 2;
-                    var endRad = baseAngle + e.coneAngleMax.Float().DegreesToRadians() - MathF.PI / 2;
+                    var baseAngle = e.FaceMe ? MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()).DegreesToRadians() + MathF.PI : 0;
+                    var startRad = baseAngle + e.coneAngleMin.Float().DegreesToRadians() + MathF.PI / 2;
+                    var endRad = baseAngle + e.coneAngleMax.Float().DegreesToRadians() + MathF.PI / 2;
                     AddCone(pos, startRad, endRad, e, e.radius); 
                 }
                 else
@@ -927,12 +924,18 @@ public unsafe class Splatoon : IDalamudPlugin
                         var angle = e.FaceMe ?
                             (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()) - x.Float())).DegreesToRadians()
                             : (-x.Float()).DegreesToRadians();
+                        var baseAngle = e.FaceMe ?
+                            (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()))).DegreesToRadians()
+                            : 0;
                         AddConeLine(pos, baseAngle, angle, e, e.radius);
                     }
                     {
                         var angle = e.FaceMe ?
                             (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()) - e.coneAngleMax.Float())).DegreesToRadians()
                             : (-e.coneAngleMax.Float()).DegreesToRadians();
+                        var baseAngle = e.FaceMe ?
+                            (180 - (MathHelper.GetRelativeAngle(new Vector2(e.refX + e.offX, e.refY + e.offY), Marking.GetPlayer(e.faceplayer).Position.ToVector2()))).DegreesToRadians()
+                            : 0;
                         AddConeLine(pos, baseAngle, angle, e, e.radius);
                     }
                 }

--- a/Splatoon/Structures/DisplayObjectInterfaces.cs
+++ b/Splatoon/Structures/DisplayObjectInterfaces.cs
@@ -100,5 +100,25 @@ public class DisplayObjectPolygon : DisplayObject
     }
 }
 
+public class DisplayObjectCone : DisplayObject
+{
+    public float x, y, z, radius, thickness;
+    public float startRad, endRad;
+    public uint color;
+    public bool filled;
+    public DisplayObjectCone(float x, float y, float z, float radius, float startRad, float endRad, float thickness, uint color, bool filled)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.radius = radius;
+        this.startRad = startRad;
+        this.endRad = endRad;
+        this.thickness = thickness;
+        this.color = color;
+        this.filled = filled;
+    }
+}
+
 public interface DisplayObject { }
 


### PR DESCRIPTION
When i was testing the code, i noticed that when e.FaceMe == true, the sector is growing clockwise, and when e.FaceMe == false, the sector is growing counterclockwise. 
For example, in the case where the angle of the element is set to -10 ~ 50 and the facing target stands at 0-degree direction, the sector drawn is reversed when e.FaceMe is different. 
I don't know if this is intentional, so I only implemented the e.type==5 case.