### PR TITLE
Add NamePlateIconId as a targettable attribute for Layouts.

### DIFF
--- a/Splatoon/Gui/Layouts/Elements/LayoutDrawElement.cs
+++ b/Splatoon/Gui/Layouts/Elements/LayoutDrawElement.cs
@@ -290,6 +290,15 @@ unsafe partial class CGui
                             }
                         }
                     }
+                    else if (el.refActorComparisonType == 9)
+                    {
+                        ImGui.SetNextItemWidth(200f);
+                        ImGuiEx.InputUint("##nameplateiconid" + i + k, ref el.refActorNamePlateIconID);
+                        if (ImGui.IsItemHovered())
+                        {
+                            ImGui.SetTooltip("Decimal input");
+                        }
+                    }
 
                     if (Svc.Targets.Target != null && !el.refActorComparisonType.EqualsAny(7, 8))
                     {
@@ -305,6 +314,7 @@ unsafe partial class CGui
                                 el.refActorNPCNameID = c.NameId;
                             }
                             el.refActorNPCID = Svc.Targets.Target.Struct()->GetNameId();
+                            el.refActorNamePlateIconID = Svc.Targets.Target.Struct()->NamePlateIconId;
                         }
                     }
                     SImGuiEx.SizedText("Targetability: ".Loc(), WidthElement);

--- a/Splatoon/Serializables/Element.cs
+++ b/Splatoon/Serializables/Element.cs
@@ -37,7 +37,8 @@ public class Element
             "Placeholder".Loc(),
             "NPC Name ID".Loc(),
             "VFX Path".Loc(),
-            "Object Effect".Loc()
+            "Object Effect".Loc(),
+            "Icon ID".Loc()
         };
     }
 
@@ -99,6 +100,7 @@ public class Element
     [DefaultValue(0)] public uint refActorTargetingYou = 0;
     [DefaultValue("")] public List<string> refActorPlaceholder = new();
     [DefaultValue(0)] public uint refActorNPCNameID = 0;
+    [DefaultValue(0)] public uint refActorNamePlateIconID = 0;
     [DefaultValue(false)] public bool refActorComparisonAnd = false;
     [DefaultValue(false)] public bool refActorRequireCast = false;
     [DefaultValue(false)] public bool refActorCastReverse = false;
@@ -130,6 +132,7 @@ public class Element
     /// 6: Name ID | 
     /// 7: VFX Path |
     /// 8: Object Effect
+    /// 9: Icon ID
     /// </summary>
     [DefaultValue(0)] public int refActorComparisonType = 0;
     /// <summary>
@@ -328,6 +331,11 @@ public class Element
     public bool ShouldSerializerefActorObjectEffectData1()
     {
         return refActorComparisonType == 8 || refActorComparisonAnd;
+    }
+
+    public bool ShouldSerializerefActorNamePlateIconId()
+    {
+        return refActorComparisonType == 9 || refActorComparisonAnd;
     }
 
     public bool ShouldSerializeRotationMax()

--- a/Splatoon/Splatoon.cs
+++ b/Splatoon/Splatoon.cs
@@ -963,7 +963,8 @@ public unsafe class Splatoon : IDalamudPlugin
              (e.refActorPlaceholder.Count == 0 || e.refActorPlaceholder.Any(x => ResolvePlaceholder(x) == o.Address)) &&
              (e.refActorNPCNameID == 0 || (o is ICharacter c2 && c2.NameId == e.refActorNPCNameID)) &&
              (e.refActorVFXPath == "" || (AttachedInfo.TryGetSpecificVfxInfo(o, e.refActorVFXPath, out var info) && info.Age.InRange(e.refActorVFXMin, e.refActorVFXMax))) &&
-             ((e.refActorObjectEffectData1 == 0 && e.refActorObjectEffectData2 == 0) || (AttachedInfo.ObjectEffectInfos.TryGetValue(o.Address, out var einfo) && IsObjectEffectMatches(e, o, einfo)));
+             ((e.refActorObjectEffectData1 == 0 && e.refActorObjectEffectData2 == 0) || (AttachedInfo.ObjectEffectInfos.TryGetValue(o.Address, out var einfo) && IsObjectEffectMatches(e, o, einfo)) &&
+             (e.refActorNamePlateIconID == 0 || o.Struct()->NamePlateIconId == e.refActorNamePlateIconID));
         }
         else
         {
@@ -976,6 +977,7 @@ public unsafe class Splatoon : IDalamudPlugin
             if (e.refActorComparisonType == 6 && o is ICharacter c2 && c2.NameId == e.refActorNPCNameID) return true;
             if (e.refActorComparisonType == 7 && AttachedInfo.TryGetSpecificVfxInfo(o, e.refActorVFXPath, out var info) && info.Age.InRange(e.refActorVFXMin, e.refActorVFXMax)) return true;
             if (e.refActorComparisonType == 8 && AttachedInfo.ObjectEffectInfos.TryGetValue(o.Address, out var einfo) && IsObjectEffectMatches(e, o, einfo)) return true;
+            if (e.refActorComparisonType == 9 && o.Struct()->NamePlateIconId == e.refActorNamePlateIconID) return true;
             return false;
         }
     }


### PR DESCRIPTION
A nice to have that eliminates the need to load a Script (Generic/QuestHighlighter, in this case) to target GameObject->NamePlateIconId.