### PR TITLE
[add] Added OnStartingCast(IBattleChara battleChar, uint castId) event methods for Script.

### DIFF
--- a/Splatoon/Memory/AttachedInfo.cs
+++ b/Splatoon/Memory/AttachedInfo.cs
@@ -169,6 +169,7 @@ public unsafe static class AttachedInfo
                         {
                             text = $"{b.Name} starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
                         }
+                        ScriptingProcessor.OnStartingCast(b, b.CastActionId);
                         P.ChatMessageQueue.Enqueue(text);
                         if (P.Config.Logging)
                         {

--- a/Splatoon/SplatoonScripting/ScriptingProcessor.cs
+++ b/Splatoon/SplatoonScripting/ScriptingProcessor.cs
@@ -455,6 +455,21 @@ internal static partial class ScriptingProcessor
         }
     }
 
+    internal static void OnStartingCast(IBattleChara battleChar, uint castId)
+    {
+        for (var i = 0; i < Scripts.Count; i++)
+        {
+            if (Scripts[i].IsEnabled)
+            {
+                try
+                {
+                    Scripts[i].OnStartingCast(battleChar, castId);
+                }
+                catch (Exception e) { Scripts[i].LogError(e, nameof(SplatoonScript.OnObjectEffect)); }
+            }
+        }
+    }
+
     internal static void OnMessage(string Message)
     {
         for (var i = 0; i < Scripts.Count; i++)

--- a/Splatoon/SplatoonScripting/SplatoonScript.cs
+++ b/Splatoon/SplatoonScripting/SplatoonScript.cs
@@ -119,6 +119,13 @@ public abstract class SplatoonScript
     public virtual void OnVFXSpawn(uint target, string vfxPath) { }
 
     /// <summary>
+    /// Will be called when a hostile object starts casting. These are the same messages which layout trigger system receives. This method will only be called if a script is enabled.
+    /// </summary>
+    /// <param name="battleChar">BattleChara object that is casting.</param>
+    /// <param name="castId">ID of cast action.</param>
+    public virtual void OnStartingCast(IBattleChara battleChar, uint castId) { }
+
+    /// <summary>
     /// Will be called whenever plugin processes a message. These are the same messages which layout trigger system receives. This method will only be called if a script is enabled.
     /// </summary>
     /// <param name="Message"></param>

--- a/SplatoonScripts/Tests/CastStartingTest.cs
+++ b/SplatoonScripts/Tests/CastStartingTest.cs
@@ -1,0 +1,22 @@
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using ECommons.Logging;
+using Splatoon.SplatoonScripting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SplatoonScriptsOfficial.Tests;
+internal class CastStartingTest :SplatoonScript
+{
+    public override HashSet<uint> ValidTerritories => new();
+
+    public override void OnStartingCast(IBattleChara battleChar, uint castId)
+    {
+        if (battleChar.NameId != 0)
+        {
+            PluginLog.Information($"Starting cast test: {battleChar.Name} ({battleChar.NameId}) is casting {castId}");
+        }
+    }
+}


### PR DESCRIPTION
I added it because I was the one who suggested it.
I want to get the same clone with a different event handler than OnMessage, for example, the one that appears in the tag match of R3S. Since the clone can only be identified by GameObjectID, I wanted to add it because IBattleChara was needed.