### PR TITLE
[fix] Fix dangerous code

### DIFF
--- a/Splatoon/Memory/AttachedInfo.cs
+++ b/Splatoon/Memory/AttachedInfo.cs
@@ -169,7 +169,7 @@ public unsafe static class AttachedInfo
                         {
                             text = $"{b.Name} starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
                         }
-                        ScriptingProcessor.OnStartingCast(b, b.CastActionId);
+                        ScriptingProcessor.OnStartingCast(b.EntityId, b.CastActionId);
                         P.ChatMessageQueue.Enqueue(text);
                         if (P.Config.Logging)
                         {

--- a/Splatoon/SplatoonScripting/ScriptingProcessor.cs
+++ b/Splatoon/SplatoonScripting/ScriptingProcessor.cs
@@ -455,7 +455,7 @@ internal static partial class ScriptingProcessor
         }
     }
 
-    internal static void OnStartingCast(IBattleChara battleChar, uint castId)
+    internal static void OnStartingCast(uint target, uint castId)
     {
         for (var i = 0; i < Scripts.Count; i++)
         {
@@ -463,7 +463,7 @@ internal static partial class ScriptingProcessor
             {
                 try
                 {
-                    Scripts[i].OnStartingCast(battleChar, castId);
+                    Scripts[i].OnStartingCast(target, castId);
                 }
                 catch (Exception e) { Scripts[i].LogError(e, nameof(SplatoonScript.OnObjectEffect)); }
             }

--- a/Splatoon/SplatoonScripting/SplatoonScript.cs
+++ b/Splatoon/SplatoonScripting/SplatoonScript.cs
@@ -121,9 +121,9 @@ public abstract class SplatoonScript
     /// <summary>
     /// Will be called when a hostile object starts casting. These are the same messages which layout trigger system receives. This method will only be called if a script is enabled.
     /// </summary>
-    /// <param name="battleChar">BattleChara object that is casting.</param>
+    /// <param name="target">Object ID that is targeted by VFX.</param>
     /// <param name="castId">ID of cast action.</param>
-    public virtual void OnStartingCast(IBattleChara battleChar, uint castId) { }
+    public virtual void OnStartingCast(uint target, uint castId) { }
 
     /// <summary>
     /// Will be called whenever plugin processes a message. These are the same messages which layout trigger system receives. This method will only be called if a script is enabled.

--- a/SplatoonScripts/Tests/CastStartingTest.cs
+++ b/SplatoonScripts/Tests/CastStartingTest.cs
@@ -12,9 +12,9 @@ internal class CastStartingTest :SplatoonScript
 {
     public override HashSet<uint> ValidTerritories => new();
 
-    public override void OnStartingCast(IBattleChara battleChar, uint castId)
+    public override void OnStartingCast(uint target, uint castId)
     {
-        if (battleChar.NameId != 0)
+        if (target.TryGetObject(out var obj) && obj is IBattleChara battleChar)
         {
             PluginLog.Information($"Starting cast test: {battleChar.Name} ({battleChar.NameId}) is casting {castId}");
         }


### PR DESCRIPTION
Limiana said it was fine to leave it as is, but I was concerned about the danger and lack of consistency, so I modified it to pass the EntityID as a uint, just like the other methods.