### PR TITLE
[fix] R2S scripting improvements

### DIFF
--- a/Splatoon/Memory/AttachedInfo.cs
+++ b/Splatoon/Memory/AttachedInfo.cs
@@ -169,7 +169,7 @@ public unsafe static class AttachedInfo
                         {
                             text = $"{b.Name} starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
                         }
-                        ScriptingProcessor.OnStartingCast(b.EntityId, b.CastActionId);
+                        ScriptingProcessor.OnStartingCast(b.DataId, b.CastActionId);
                         P.ChatMessageQueue.Enqueue(text);
                         if (P.Config.Logging)
                         {

--- a/Splatoon/Memory/AttachedInfo.cs
+++ b/Splatoon/Memory/AttachedInfo.cs
@@ -169,7 +169,7 @@ public unsafe static class AttachedInfo
                         {
                             text = $"{b.Name} starts casting {b.CastActionId} ({b.NameId}>{b.CastActionId})";
                         }
-                        ScriptingProcessor.OnStartingCast(b.DataId, b.CastActionId);
+                        ScriptingProcessor.OnStartingCast(b.EntityId, b.CastActionId);
                         P.ChatMessageQueue.Enqueue(text);
                         if (P.Config.Logging)
                         {

--- a/Splatoon/SplatoonScripting/ScriptingProcessor.cs
+++ b/Splatoon/SplatoonScripting/ScriptingProcessor.cs
@@ -455,7 +455,7 @@ internal static partial class ScriptingProcessor
         }
     }
 
-    internal static void OnStartingCast(uint target, uint castId)
+    internal static void OnStartingCast(uint source, uint castId)
     {
         for (var i = 0; i < Scripts.Count; i++)
         {
@@ -463,7 +463,7 @@ internal static partial class ScriptingProcessor
             {
                 try
                 {
-                    Scripts[i].OnStartingCast(target, castId);
+                    Scripts[i].OnStartingCast(source, castId);
                 }
                 catch (Exception e) { Scripts[i].LogError(e, nameof(SplatoonScript.OnObjectEffect)); }
             }

--- a/Splatoon/SplatoonScripting/SplatoonScript.cs
+++ b/Splatoon/SplatoonScripting/SplatoonScript.cs
@@ -121,9 +121,9 @@ public abstract class SplatoonScript
     /// <summary>
     /// Will be called when a hostile object starts casting. These are the same messages which layout trigger system receives. This method will only be called if a script is enabled.
     /// </summary>
-    /// <param name="target">Object ID that is targeted by VFX.</param>
+    /// <param name="source">Object ID that is source by VFX.</param>
     /// <param name="castId">ID of cast action.</param>
-    public virtual void OnStartingCast(uint target, uint castId) { }
+    public virtual void OnStartingCast(uint source, uint castId) { }
 
     /// <summary>
     /// Will be called whenever plugin processes a message. These are the same messages which layout trigger system receives. This method will only be called if a script is enabled.

--- a/SplatoonScripts/Duties/Dawntrail/R2S Venom Love Pair Split.cs
+++ b/SplatoonScripts/Duties/Dawntrail/R2S Venom Love Pair Split.cs
@@ -3,6 +3,7 @@ using ECommons.GameHelpers;
 using ECommons.Hooks;
 using ECommons.Hooks.ActionEffectTypes;
 using ECommons.Logging;
+using Splatoon;
 using Splatoon.SplatoonScripting;
 using System;
 using System.Collections.Generic;
@@ -35,71 +36,74 @@ public class R2S_Venom_Love_Pair_Split : SplatoonScript
         Controller.RegisterElementFromCode("split", "{\"Name\":\"split\",\"type\":1,\"Enabled\":false,\"radius\":6.0,\"color\":4278190335,\"Filled\":false,\"fillIntensity\":0.14,\"originFillColor\":587202815,\"endFillColor\":587202815,\"overlayTextColor\":4278190335,\"overlayVOffset\":1.0,\"overlayText\":\"<< Spread >>\",\"refActorComparisonType\":1,\"includeRotation\":true,\"FaceMe\":true,\"refActorTetherTimeMin\":0.0,\"refActorTetherTimeMax\":0.0}");
     }
 
-    public override void OnUpdate()
+    public override void OnStartingCast(uint source, uint castId)
     {
-        if (Player.Object.StatusList.Any(x => x.StatusId == PoisonResistanceDownDebuffID) && IsShow && !IsAdd)
-        {
-            IsAdd = true;
-            HideElement();
-        }
+        PluginLog.Log($"StartingCast {source} {castId}");
+        if (source == 0 || source != 16941) return;
 
-        if (IsAdd && !(Player.Object.StatusList.Any(x => x.StatusId == PoisonResistanceDownDebuffID)))
-        {
-            IsAdd = false;
-        }
-    }
-
-    public override void OnVFXSpawn(uint target, string vfxPath)
-    {
-        if (IsShow && vfxPath.Contains("vfx/common/eff/m0906_stlp_ht4_03k2.avfx"))
-        {
-            HideElement();
-        }
-    }
-
-    public override void OnMessage(string Message)
-    {
-        if (Message.Contains("12685>37252") || (Message.Contains("12685>39688")))
+        if ((castId == 37252) || (castId == 39688) )
         {
             LatchNextPairSplit = PairSplit.Split;
         }
-        else if (Message.Contains("12685>37253") || (Message.Contains("12685>39689")))
+
+        if ((castId == 37253) || (castId == 39689))
         {
             LatchNextPairSplit = PairSplit.Pair;
         }
-        else if (Message.Contains("12685>37254") ||
-                (Message.Contains("12685>37255")) ||
-                (Message.Contains("12685>39696")) ||
-                (Message.Contains("12685>39697")))
+
+        if ((castId == 37254) || (castId == 37255) || (castId == 39692) || (castId == 39693))
         {
             ShowElement();
         }
-        else
+
+    }
+
+    public override void OnActionEffectEvent(ActionEffectSet set)
+    {
+        if (set.Action == null || (set.Source == null)) return;
+        if (set.Source.DataId == 0) return;
+
+        PluginLog.Log($"ActionEffectEvent {set.Action.Name} {set.Action.RowId} {set.Source.DataId}");
+
+        if ((set.Action.RowId == 37256) && (set.Source.DataId == 16945))
         {
-            // NOP
+            HideElement();
+        }
+
+        if ((set.Action.RowId == 39691) && (set.Source.DataId == 16943))
+        {
+            HideElement();
         }
     }
 
     private void ShowElement()
     {
-        if (LatchNextPairSplit == PairSplit.Pair)
+        Element? element = Controller.GetElementByName("Pair");
+        if ((LatchNextPairSplit == PairSplit.Pair) && element != null && !element.Enabled)
         {
             Controller.GetElementByName("Pair")!.Enabled = true;
         }
-        else if (LatchNextPairSplit == PairSplit.Split)
+
+        element = Controller.GetElementByName("split");
+        if ((LatchNextPairSplit == PairSplit.Split) && element != null && !element.Enabled)
         {
             Controller.GetElementByName("split")!.Enabled = true;
         }
-        else
-        {
-        }
-        IsShow = true;
     }
 
     private void HideElement()
     {
-        Controller.GetRegisteredElements().Each(x => x.Value.Enabled = false);
-        IsShow = false;
+        Element? element = Controller.GetElementByName("Pair");
+        if (element != null && element.Enabled)
+        {
+            Controller.GetElementByName("Pair")!.Enabled = false;
+        }
+
+        element = Controller.GetElementByName("split");
+        if (element != null && element.Enabled)
+        {
+            Controller.GetElementByName("split")!.Enabled = false;
+        }
     }
 
     public override void OnReset()

--- a/SplatoonScripts/Duties/Dawntrail/R2S Venom Love Pair Split.cs
+++ b/SplatoonScripts/Duties/Dawntrail/R2S Venom Love Pair Split.cs
@@ -23,7 +23,7 @@ public class R2S_Venom_Love_Pair_Split : SplatoonScript
     }
     public override HashSet<uint>? ValidTerritories { get; } = [1228];
 
-    public override Metadata? Metadata => new(1, "Redmoon");
+    public override Metadata? Metadata => new(2, "Redmoon");
 
     const uint PoisonResistanceDownDebuffID = 3935;
     bool IsShow = false;
@@ -38,8 +38,12 @@ public class R2S_Venom_Love_Pair_Split : SplatoonScript
 
     public override void OnStartingCast(uint source, uint castId)
     {
-        PluginLog.Log($"StartingCast {source} {castId}");
-        if (source == 0 || source != 16941) return;
+        var sourceObj = source.GetObject();
+        if (sourceObj == null)
+            return;
+
+        if (sourceObj.DataId == 0 || sourceObj.DataId != 16941)
+            return;
 
         if ((castId == 37252) || (castId == 39688) )
         {
@@ -62,8 +66,6 @@ public class R2S_Venom_Love_Pair_Split : SplatoonScript
     {
         if (set.Action == null || (set.Source == null)) return;
         if (set.Source.DataId == 0) return;
-
-        PluginLog.Log($"ActionEffectEvent {set.Action.Name} {set.Action.RowId} {set.Source.DataId}");
 
         if ((set.Action.RowId == 37256) && (set.Source.DataId == 16945))
         {


### PR DESCRIPTION
A problem occurred due to a null reference, so it was fixed and improved.
- OnMessage() is called frequently, so it was changed to OnStartingCast() to reduce processing.
- OnUpdate() is called every tick, so the processing was moved to OnActionEffectEvent() to reduce processing.
- Changed to refer to set instead of Player.Object, and strictly checks whether set and set.action are null, so null reference errors do not occur.
- OnVfx() can also be integrated with OnActionEffectEvent(), so it was changed to process with OnActionEffectEvent().
- Corrected the typo that said "target" as the argument to OnStartingCast should be "source."
- Changed the argument to OnStartingCast to pass DataID instead of EntityID as the argument to sourceID.