### PR TITLE
Create 93 - Worqor Zormor.md

### DIFF
--- a/Presets/Dawntrail/Dungeons/93 - Worqor Zormor.md
+++ b/Presets/Dawntrail/Dungeons/93 - Worqor Zormor.md
@@ -1,0 +1,23 @@
+## Worqor Zormor
+
+Presets contributed by `EnjoyingTofu`
+
+### Ryoqor Terteh
+
+```
+~Lv2~{"Name":"Ryoqor Terteh Frozen Swirls","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"DCond":5,"ElementsL":[{"Name":"Unsafe Circle","type":1,"offY":28.0,"radius":14.93,"color":3355706622,"fillIntensity":0.508,"refActorRequireCast":true,"refActorCastId":[36272,36271],"refActorComparisonType":7,"includeRotation":true,"refActorVFXPath":"vfx/channeling/eff/chn_m0320_ice_0c2.avfx","refActorVFXMax":11000,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Match":"36271"}]}
+~Lv2~{"Name":"Ryoqor Terteh Ice Scream","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"DCond":5,"ElementsL":[{"Name":"Unsafe Box","type":3,"refX":20.18,"offX":0.08,"radius":10.12,"color":3355443453,"fillIntensity":0.514,"refActorRequireCast":true,"refActorCastId":[36270],"refActorCastTimeMax":0.5,"refActorComparisonType":7,"includeRotation":true,"AdditionalRotation":1.5707964,"refActorVFXPath":"vfx/channeling/eff/chn_m0320_ice_0c2.avfx","refActorVFXMax":11000,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Match":"36270","FireOnce":true}]}
+```
+### Kahderyo
+
+```
+~Lv2~{"Name":"Kahderyo Earthen Shot 2","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"DCond":5,"ElementsL":[{"Name":"Unsafe 1","type":2,"refX":-51.25427,"refY":-36.48286,"refZ":322.79077,"offX":-70.5244,"offY":-70.08405,"offZ":323.05984,"radius":7.0,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0},{"Name":"Unsafe 2","type":2,"refX":-30.093103,"refY":-60.204388,"refZ":322.469,"offX":-68.20364,"offY":-38.212524,"offZ":322.10388,"radius":7.0,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0},{"Name":"Unsafe 3","type":2,"refX":-34.127335,"refY":-70.59569,"refZ":321.90598,"offX":-79.879395,"offY":-62.494244,"offZ":322.58533,"radius":7.0,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Duration":6.0,"Match":"MapEffect: 33, 16, 32"}]}
+~Lv2~{"Name":"Kahderyo Wind Shot","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"DCond":5,"ElementsL":[{"Name":"Safe Circle","type":1,"offX":-9.98,"radius":9.0,"Donut":19.96,"fillIntensity":0.648,"refActorNPCNameID":12703,"refActorRequireCast":true,"refActorCastId":[36284],"refActorComparisonType":6,"includeRotation":true,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Duration":5.5,"Match":"VFX vfx/lockon/eff/y6d2_cb02_trg_c2.avfx","FireOnce":true}]}
+~Lv2~{"Name":"Kahderyo Towers","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"ElementsL":[{"Name":"Tower AOE","type":1,"radius":6.0,"Donut":23.26,"fillIntensity":0.597,"refActorRequireCast":true,"refActorCastId":[36153,36285],"refActorComparisonType":7,"refActorVFXPath":"vfx/lockon/eff/com_share0c.avfx","refActorVFXMax":6500,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Duration":6.3,"Match":"63, 323, -57>"}]}
+~Lv2~{"Name":"Kahderyo Earthen Shot","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"DCond":5,"ElementsL":[{"Name":"","type":1,"offX":-10.26,"radius":15.09,"fillIntensity":0.166,"refActorNPCNameID":12703,"refActorRequireCast":true,"refActorCastId":[36295],"refActorComparisonType":6,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Duration":6.0,"Match":"Earthen Shot","FireOnce":true}]}
+```
+
+### Gurgurlur
+```
+~Lv2~{"Name":"Gurgurlur Wind","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"ElementsL":[{"Name":"Avoid","type":1,"offY":0.34,"radius":4.13,"overlayText":"AVOID","refActorNPCID":12706,"refActorComparisonType":4,"includeHitbox":true,"includeRotation":true,"onlyVisible":true,"LineEndB":1,"AdditionalRotation":4.735078,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0,"faceplayer":"<d1>"},{"Name":"Directional Arrow","type":3,"refX":6.36,"radius":0.0,"color":3358523647,"fillIntensity":0.345,"thicc":8.2,"refActorNPCID":12706,"refActorComparisonType":4,"includeRotation":true,"LineEndA":1,"AdditionalRotation":4.712389,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}]}
+~Lv2~{"Name":"Gurglurlur Erupting Peaks","Group":"93 - Worqor Zormor","ZoneLockH":[1193],"ElementsL":[{"Name":"AOE Tile First Explosion","type":3,"refX":-5.0,"refY":-0.04,"offX":5.0,"radius":5.0,"fillIntensity":0.542,"refActorNPCID":12705,"refActorRequireCast":true,"refActorCastId":[36303],"refActorComparisonType":4,"includeRotation":true,"AdditionalRotation":1.5760324,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}]}


### PR DESCRIPTION
Updated presets for Ryoqor Terteh which freezes and draws the unsafe delayed AOE.

Updated presets for Kahderyo which draws Unsafe spots for Earthen Shot,Wind shot and Towers. It also draws the unsafe spots for Earthen Shot 2 as they are yellow and particularly hard to see.

Updated presets for Gurgurlur which draws unsafe zones on the wind and directional arrow. It also draws the unsafe first tile which blows up first, which is useful for a later knockback mechanic to avoid it.