### PR TITLE
UCOB Twintania Twisters Add a script and a preset

### DIFF
--- a/Presets/Stormblood/Duties/Ultimate - The Unending Coil of Bahamud.md
+++ b/Presets/Stormblood/Duties/Ultimate - The Unending Coil of Bahamud.md
@@ -8,6 +8,15 @@
 ```
 https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Stormblood/UCOB%20Tethers.cs
 ```
+# Twintania phase
+[International] Twisters: Show their location as soon as they appear
+```
+~Lv2~{"Name":"Twintania Twisters","Group":"UCOB","ZoneLockH":[733],"DCond":5,"ElementsL":[{"Name":"","type":1,"radius":0.9,"refActorModelID":480,"refActorPlaceholder":[],"refActorNPCNameID":1482,"refActorComparisonAnd":true,"refActorComparisonType":6,"DistanceSourceX":0.21287155,"DistanceSourceY":9.486858,"DistanceMax":24.0,"refActorTetherTimeMin":0.0,"refActorTetherTimeMax":0.0}],"UseTriggers":true,"Triggers":[{"Type":2,"Duration":7.0,"Match":"Twintania readies Twister.","MatchDelay":2.0}]}
+```
+[International] Twisters: Draws yellow markers around party members before they lock in
+```
+https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Stormblood/UCOB%20Twisters.cs
+```
 
 # Nael phase
 [International] [Script] Dragon baits (5 dragons charging towards marked players)

--- a/SplatoonScripts/Duties/Stormblood/UCOB Twisters.cs
+++ b/SplatoonScripts/Duties/Stormblood/UCOB Twisters.cs
@@ -54,10 +54,7 @@ public class UCOB_Twisters : SplatoonScript
         {
             //DuoLog.Debug($"Twistin' time. src {source}");
             active = true;
-            Task.Delay(2300).ContinueWith(_ =>
-            {
-                Off();
-            });
+            this.Controller.ScheduleReset(2300);
             for (int i = 0; i < players.Count; ++i)
             {
                 var p = players[i];
@@ -66,6 +63,11 @@ public class UCOB_Twisters : SplatoonScript
                 elem.Enabled = true;
             }
         }
+    }
+
+    public override void OnReset()
+    {
+        Off();
     }
 
     public override void OnUpdate()

--- a/SplatoonScripts/Duties/Stormblood/UCOB Twisters.cs
+++ b/SplatoonScripts/Duties/Stormblood/UCOB Twisters.cs
@@ -1,0 +1,125 @@
+﻿using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Plugin;
+using ECommons;
+using ECommons.Configuration;
+using ECommons.DalamudServices;
+using ECommons.GameFunctions;
+using ECommons.Hooks;
+using ECommons.ImGuiMethods;
+using ECommons.Logging;
+using ECommons.MathHelpers;
+using ImGuiNET;
+using Splatoon;
+using Splatoon.SplatoonScripting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SplatoonScriptsOfficial.Duties.Stormblood;
+
+public class UCOB_Twisters : SplatoonScript
+{
+    public override HashSet<uint> ValidTerritories => new() { 733 };
+
+    public override Metadata? Metadata => new(1, "Enthusiastus");    
+
+    private List<Element> _elements = new List<Element>();
+    private bool active = false;
+    private List<IPlayerCharacter> players = FakeParty.Get().ToList();
+
+    Config Conf => this.Controller.GetConfig<Config>();
+
+    string TestOverride = "";
+    IPlayerCharacter PC => TestOverride != "" && FakeParty.Get().FirstOrDefault(x => x.Name.ToString() == TestOverride) is IPlayerCharacter pc ? pc : Svc.ClientState.LocalPlayer!;
+
+    public override void OnSetup()
+    {
+        for(var i = 0; i < 8; i++)
+        {
+            var elem = new Element(0) { Enabled = false, radius = 1.0f, thicc = 2f, color = 0xFF03BAFC };
+            this.Controller.TryRegisterElement($"twister{i}", elem);
+            _elements.Add(elem);
+        }
+    }
+
+    //> [08.09.2024 21:37:07 + 02:00] Message: Twintania starts casting 9898 (1482>9898)
+    public override void OnStartingCast(uint source, uint castId) {
+        if(castId == 9898)
+        {
+            //DuoLog.Debug($"Twistin' time. src {source}");
+            active = true;
+            Task.Delay(2300).ContinueWith(_ =>
+            {
+                Off();
+            });
+            for (int i = 0; i < players.Count; ++i)
+            {
+                var p = players[i];
+                var elem = _elements[i];
+                elem.SetRefPosition(p.Position);
+                elem.Enabled = true;
+            }
+        }
+    }
+
+    public override void OnUpdate()
+    {
+        if(active)
+        {
+            for (int i = 0; i < players.Count; ++i)
+            {
+                var p = players[i];
+                var elem = _elements[i];
+                elem.SetRefPosition(p.Position);
+                elem.Enabled = true;
+            }
+        }
+    }
+
+    public override void OnMessage(string Message)
+    {
+        //
+    }
+
+    void Off()
+    {
+        players = FakeParty.Get().ToList();
+        active = false;
+        foreach (var elem in _elements)
+        {
+            elem.Enabled = false;
+            elem.color = 0xFF03BAFC;
+        }
+    }
+
+    public override void OnDirectorUpdate(DirectorUpdateCategory category)
+    {
+        if (category.EqualsAny(DirectorUpdateCategory.Commence, DirectorUpdateCategory.Recommence, DirectorUpdateCategory.Wipe))
+        {
+            Off();
+        }
+    }
+
+    public void LockTwisters()
+    {
+        foreach (var e in _elements) {
+            e.color = 0xFF0000FF;
+        }
+        active = false;
+    }
+
+    public override void OnSettingsDraw()
+    {
+        //
+    }
+
+    public class Config : IEzConfig
+    {
+    }
+}

--- a/SplatoonScripts/update.csv
+++ b/SplatoonScripts/update.csv
@@ -45,6 +45,7 @@ SplatoonScriptsOfficial.Duties.Dawntrail@R2S_Venom_Love_Pair_Split,2,https://git
 SplatoonScriptsOfficial.Duties.Dawntrail@R4S_Unsafe_Cannon,2,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/R4S Unsafe Cannon.cs
 SplatoonScriptsOfficial.Duties.Dawntrail@R4S_Electrope_Edge,9,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/R4S Electrope Edge.cs
 SplatoonScriptsOfficial.Duties.Dawntrail@R4S_Chain_Lightning,2,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/R4S Chain Lightning.cs
+SplatoonScriptsOfficial.Duties.Stormblood@UCOB_Twisters,1,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Stormblood/UCOB Twisters.cs
 SplatoonScriptsOfficial.Duties.Stormblood@UCOB_Tethers,3,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Stormblood/UCOB Tethers.cs
 SplatoonScriptsOfficial.Duties.Stormblood@UCOB_Heavensfall_Trio_Towers,6,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Stormblood/UCOB Heavensfall Trio Towers.cs
 SplatoonScriptsOfficial.Duties.Stormblood@UCOB_dragon_baits,3,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Stormblood/UCOB dragon baits.cs


### PR DESCRIPTION
The script adds yellow circles to all party members so you can predetermine where twisters might land.
Once they appear the script's circles vanish and the layout draws red warnings around them until they disappear.
Thank you to Discord user EnjoyingTofu for help with the layout