### PR TITLE
Disable drawing if player has AoE to bait and dont need to form any thing

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/The Futures Rewritten/P2 Light Rampant JP.cs
+++ b/SplatoonScripts/Duties/Dawntrail/The Futures Rewritten/P2 Light Rampant JP.cs
@@ -87,7 +87,7 @@ public class P2_Light_Rampant_JP : SplatoonScript
 
             var direction = C.Directions[count];
 
-            //DuoLog.Warning($"Direction: {direction} Count: {count}");
+            DuoLog.Warning($"Direction: {direction} Count: {count}");
             const float radius = 16f;
             var center = new Vector2(100f, 100f);
             var angle = (int)direction;


### PR DESCRIPTION
to avoid any confusing time, if the player has to bait the aoe, the script will be "turned off" - the player has to know where he/she has to be.