### PR TITLE
FRU P2 Mirror Mirror - Make marker a donut corresponding to the mirror cleave

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/The Futures Rewritten/P2 Mirror Mirror.cs
+++ b/SplatoonScripts/Duties/Dawntrail/The Futures Rewritten/P2 Mirror Mirror.cs
@@ -88,8 +88,10 @@ public class P2_Mirror_Mirror : SplatoonScript
         var element = new Element(0)
         {
             tether = true,
-            radius = 2f,
-            thicc = 6f
+            radius = 4f,
+            Donut = 10f,
+            fillIntensity = 0.4f,
+            thicc = 6f,
         };
 
         Controller.RegisterElement("Bait", element);
@@ -139,7 +141,7 @@ public class P2_Mirror_Mirror : SplatoonScript
     {
         var angle = ((int)direction - 3) % 8 * 45f;
         var position = new Vector3(100f, 0f, 100f);
-        var radius = 18f;
+        var radius = 20f;
         position += new Vector3((float)Math.Cos(MathF.PI * angle / 180f) * radius, 0f,
             (float)Math.Sin(MathF.PI * angle / 180f) * radius);
         if (Controller.TryGetElementByName("Bait", out var element))


### PR DESCRIPTION
It's more helpful to see where it's safe to go under the mirror than a simple circle in front of the mirror.