### PR TITLE
Skip render set up if there's nothing to render

### DIFF
--- a/Splatoon/RenderEngines/DirectX11/DirectX11Scene.cs
+++ b/Splatoon/RenderEngines/DirectX11/DirectX11Scene.cs
@@ -28,6 +28,7 @@ internal unsafe class DirectX11Scene : IDisposable
     private void Draw()
     {
         if(!DirectX11Renderer.Enabled) return;
+        if (DirectX11Renderer.DisplayObjects.Count == 0) return;
         uid = 0;
         void Draw(PctTexture? texture)
         {

--- a/Splatoon/RenderEngines/ImGuiLegacy/ImGuiLegacyScene.cs
+++ b/Splatoon/RenderEngines/ImGuiLegacy/ImGuiLegacyScene.cs
@@ -36,6 +36,7 @@ internal class ImGuiLegacyScene : IDisposable
 
     private void Draw()
     {
+        if (ImGuiLegacyRenderer.DisplayObjects.Count == 0) return;
         uid = 0;
         try
         {


### PR DESCRIPTION
No be perfectly honest, I don't know if this change is correct or not. If not, feel free to close this.

It seemed to me that there is no need to incur renderer setup overhead if there are no objects we actually want to draw. Skipping those significantly reduces the impact of having Splatoon running in cases where there are no actual objects to draw.