### PR TITLE
Fix dragon ordering

### DIFF
--- a/SplatoonScripts/Duties/Stormblood/UCOB dragon baits.cs
+++ b/SplatoonScripts/Duties/Stormblood/UCOB dragon baits.cs
@@ -26,7 +26,7 @@ namespace SplatoonScriptsOfficial.Duties.Stormblood
     {
         public override HashSet<uint> ValidTerritories => [733];
 
-        public override Metadata? Metadata => new(3, "NightmareXIV");
+        public override Metadata? Metadata => new(4, "NightmareXIV, damolitionn");
         private const string TargetVFX = "vfx/lockon/eff/bahamut_wyvn_glider_target_02tm.avfx";
         private int diveCnt = 0;
         private uint[] baiters = new uint[3];
@@ -151,9 +151,17 @@ namespace SplatoonScriptsOfficial.Duties.Stormblood
             }
         }
 
+        private static readonly Vector2 TrueNorth = new(-0.015319824f, -24.002502f);
         private IBattleChara[] GetOrderedDragons()
         {
-            return GetDragons().OrderBy(x => (MathHelper.GetRelativeAngle(Vector3.Zero, x.Position) + 360 - 3) % 360).ToArray();
+            return GetDragons()
+                .OrderBy(d =>
+                {
+                    var target = new Vector2(d.Position.X, d.Position.Z);
+                    float angle = MathHelper.GetRelativeAngle(TrueNorth, target);
+                    return angle;
+                })
+                .ToArray();
         }
 
         private IEnumerable<IBattleChara> GetDragons()


### PR DESCRIPTION
N dragon spawns at Position: -0.015319824 0 -24.002502 but the current implementation assumes that N would be at x:0 y:0. This hardcodes it so that N begins at -0.015319824 0 -24.002502 and adjusts from there