### PR TITLE
fix(Light Rampant): Use `LocalPlayer` from `ObjectTable`

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/The Futures Rewritten/P2 Light Rampant JP.cs
+++ b/SplatoonScripts/Duties/Dawntrail/The Futures Rewritten/P2 Light Rampant JP.cs
@@ -72,7 +72,7 @@ public class P2_Light_Rampant_JP : SplatoonScript
             {
                 _aoeTargets.Add(player.Name.ToString());
 
-                if(player.Name.ToString().Equals(Svc.ClientState.LocalPlayer.Name.ToString()))
+                if(player.Name.ToString().Equals(Svc.Objects.LocalPlayer.Name.ToString()))
                     _PlayerHasAoE = true;
 
             }


### PR DESCRIPTION
As mentioned in Dalamud’s Discord server:

> ClientState.LocalPlayer was removed, it was referring to ObjectTable.LocalPlayer the whole time

I _hope_ this is the correct change, haven’t tested but at least the script compiles this way. There might be more to it than I’m aware of…