### PR TITLE
Add Splatoon.GetActiveDrawGeometryV1 IPC for active draw snapshot

### DIFF
--- a/Splatoon/Modules/ActiveDrawGeometrySnapshot.cs
+++ b/Splatoon/Modules/ActiveDrawGeometrySnapshot.cs
@@ -1,73 +1,83 @@
-﻿using Newtonsoft.Json;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using Splatoon.RenderEngines.DirectX11;
 using Splatoon.RenderEngines.ImGuiLegacy;
 using Splatoon.Serializables;
 using Splatoon.Structures;
+using Item = (string id, string source, string Namespace, string layout, string element, string kind, string renderEngine, uint color, System.Numerics.Vector3 center, System.Numerics.Vector3 start, System.Numerics.Vector3 end, float? radius, float? innerRadius, float? outerRadius, float? lineRadius, float? facingRad, float? halfAngleRad, float? angleMinRad, float? angleMaxRad);
+using Snapshot = (int version, uint frame, uint territoryId, long generatedAtTickMs, System.Collections.Generic.List<(string id, string source, string Namespace, string layout, string element, string kind, string renderEngine, uint color, System.Numerics.Vector3 center, System.Numerics.Vector3 start, System.Numerics.Vector3 end, float? radius, float? innerRadius, float? outerRadius, float? lineRadius, float? facingRad, float? halfAngleRad, float? angleMinRad, float? angleMaxRad)> items);
 
 namespace Splatoon.Modules;
 
-internal static class ActiveDrawGeometrySnapshot
+internal static unsafe class ActiveDrawGeometrySnapshot
 {
     internal const int Version = 1;
 
-    internal static string BuildJson(List<DisplayObject> displayObjects)
-    {
-        var snapshot = new Snapshot()
-        {
-            version = Version,
-            frame = P.FrameCounter,
-            territoryId = Svc.ClientState.TerritoryType,
-            generatedAtTickMs = Environment.TickCount64,
-        };
+    private static Snapshot cachedSnapshot;
+    private static ulong cachedFrame;
+    private static bool hasCachedSnapshot;
 
-        for(var i = 0; i < displayObjects.Count; i++)
+    internal static Snapshot Build(List<DisplayObject> displayObjects)
+    {
+        var frame = Framework.Instance()->FrameCounter;
+        if (hasCachedSnapshot && cachedFrame == frame)
         {
-            if(TryCreateItem(displayObjects[i], i, out var item))
+            return cachedSnapshot;
+        }
+
+        var items = new List<Item>(displayObjects.Count);
+        for (var i = 0; i < displayObjects.Count; i++)
+        {
+            if (TryCreateItem(displayObjects[i], i, frame, out var item))
             {
-                snapshot.items.Add(item);
+                items.Add(item);
             }
         }
 
-        return JsonConvert.SerializeObject(snapshot, Formatting.None);
+        cachedSnapshot = (Version, (uint)frame, Svc.ClientState.TerritoryType, Environment.TickCount64, items);
+        cachedFrame = frame;
+        hasCachedSnapshot = true;
+        return cachedSnapshot;
     }
 
-    private static bool TryCreateItem(DisplayObject displayObject, int index, out Item item)
+    internal static void Invalidate()
     {
-        item = new()
-        {
-            id = GetId(displayObject, index),
-            source = "render",
-            Namespace = null,
-            layout = null,
-            element = null,
-            renderEngine = displayObject.RenderEngineKind.ToString(),
-            facingRad = null,
-            halfAngleRad = null,
-        };
+        hasCachedSnapshot = false;
+        cachedSnapshot = default;
+        cachedFrame = 0;
+    }
 
-        if(displayObject is DirectX11DisplayObjects.DisplayObjectCircle dxCircle)
+    private static bool TryCreateItem(DisplayObject displayObject, int index, ulong frame, out Item item)
+    {
+        item = default;
+        item.id = GetId(displayObject, index, frame);
+        item.source = "render";
+        item.renderEngine = displayObject.RenderEngineKind.ToString();
+
+        if (displayObject is DirectX11DisplayObjects.DisplayObjectCircle dxCircle)
         {
             item.kind = "circle";
             item.color = GetDisplayStyleColor(dxCircle.style);
-            item.center = MakePoint(dxCircle.origin);
+            item.center = dxCircle.origin;
             item.radius = dxCircle.outerRadius;
             return true;
         }
-        if(displayObject is DirectX11DisplayObjects.DisplayObjectDonut dxDonut)
+
+        if (displayObject is DirectX11DisplayObjects.DisplayObjectDonut dxDonut)
         {
             item.kind = "donut";
             item.color = GetDisplayStyleColor(dxDonut.style);
-            item.center = MakePoint(dxDonut.origin);
+            item.center = dxDonut.origin;
             item.innerRadius = dxDonut.innerRadius;
             item.outerRadius = dxDonut.outerRadius;
             item.radius = dxDonut.outerRadius;
             return true;
         }
-        if(displayObject is DirectX11DisplayObjects.DisplayObjectFan dxFan)
+
+        if (displayObject is DirectX11DisplayObjects.DisplayObjectFan dxFan)
         {
             item.kind = "cone";
             item.color = GetDisplayStyleColor(dxFan.style);
-            item.center = MakePoint(dxFan.origin);
+            item.center = dxFan.origin;
             item.innerRadius = dxFan.innerRadius;
             item.outerRadius = dxFan.outerRadius;
             item.radius = dxFan.outerRadius;
@@ -75,97 +85,106 @@ internal static class ActiveDrawGeometrySnapshot
             item.angleMaxRad = dxFan.angleMax;
             return true;
         }
-        if(displayObject is DirectX11DisplayObjects.DisplayObjectLine dxLine)
+
+        if (displayObject is DirectX11DisplayObjects.DisplayObjectLine dxLine)
         {
             item.kind = "line";
             item.color = dxLine.style.strokeColor;
-            item.start = MakePoint(dxLine.start);
-            item.end = MakePoint(dxLine.stop);
+            item.start = dxLine.start;
+            item.end = dxLine.stop;
             item.lineRadius = dxLine.radius;
             item.radius = dxLine.radius;
             return true;
         }
-        if(displayObject is DirectX11DisplayObjects.DisplayObjectDot dxDot)
+
+        if (displayObject is DirectX11DisplayObjects.DisplayObjectDot dxDot)
         {
             item.kind = "dot";
             item.color = dxDot.color;
-            item.center = MakePoint(dxDot.x, dxDot.y, dxDot.z);
+            item.center = new Vector3(dxDot.x, dxDot.y, dxDot.z);
             item.radius = dxDot.thickness;
             return true;
         }
-        if(displayObject is DirectX11DisplayObjects.DisplayObjectText dxText)
+
+        if (displayObject is DirectX11DisplayObjects.DisplayObjectText dxText)
         {
             item.kind = "text";
             item.color = dxText.fgcolor;
-            item.center = MakePointFromXzy(dxText.x, dxText.y, dxText.z);
+            item.center = FromXzy(dxText.x, dxText.y, dxText.z);
             return true;
         }
-        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectDonut imDonut)
+
+        if (displayObject is ImGuiLegacyDisplayObjects.DisplayObjectDonut imDonut)
         {
             item.kind = "donut";
             item.color = imDonut.color;
-            item.center = MakePointFromXzy(imDonut.x, imDonut.y, imDonut.z);
+            item.center = FromXzy(imDonut.x, imDonut.y, imDonut.z);
             item.innerRadius = imDonut.radius;
             item.outerRadius = imDonut.radius + imDonut.donut;
             item.radius = item.outerRadius;
             return true;
         }
-        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectCircle imCircle)
+
+        if (displayObject is ImGuiLegacyDisplayObjects.DisplayObjectCircle imCircle)
         {
             item.kind = "circle";
             item.color = imCircle.color;
-            item.center = MakePointFromXzy(imCircle.x, imCircle.y, imCircle.z);
+            item.center = FromXzy(imCircle.x, imCircle.y, imCircle.z);
             item.radius = imCircle.radius;
             return true;
         }
-        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectCone imCone)
+
+        if (displayObject is ImGuiLegacyDisplayObjects.DisplayObjectCone imCone)
         {
             item.kind = "cone";
             item.color = imCone.color;
-            item.center = MakePointFromXzy(imCone.x, imCone.y, imCone.z);
+            item.center = FromXzy(imCone.x, imCone.y, imCone.z);
             item.radius = imCone.radius;
             item.outerRadius = imCone.radius;
             item.angleMinRad = imCone.startRad;
             item.angleMaxRad = imCone.endRad;
             return true;
         }
-        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectLine imLine)
+
+        if (displayObject is ImGuiLegacyDisplayObjects.DisplayObjectLine imLine)
         {
             item.kind = "line";
             item.color = imLine.color;
-            item.start = MakePointFromXzy(imLine.ax, imLine.ay, imLine.az);
-            item.end = MakePointFromXzy(imLine.bx, imLine.by, imLine.bz);
+            item.start = FromXzy(imLine.ax, imLine.ay, imLine.az);
+            item.end = FromXzy(imLine.bx, imLine.by, imLine.bz);
             item.lineRadius = 0f;
             item.radius = 0f;
             return true;
         }
-        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectDot imDot)
+
+        if (displayObject is ImGuiLegacyDisplayObjects.DisplayObjectDot imDot)
         {
             item.kind = "dot";
             item.color = imDot.color;
-            item.center = MakePointFromXzy(imDot.x, imDot.y, imDot.z);
+            item.center = FromXzy(imDot.x, imDot.y, imDot.z);
             item.radius = imDot.thickness;
             return true;
         }
-        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectText imText)
+
+        if (displayObject is ImGuiLegacyDisplayObjects.DisplayObjectText imText)
         {
             item.kind = "text";
             item.color = imText.fgcolor;
-            item.center = MakePointFromXzy(imText.x, imText.y, imText.z);
+            item.center = FromXzy(imText.x, imText.y, imText.z);
             return true;
         }
 
         return false;
     }
 
-    private static string GetId(DisplayObject displayObject, int index)
+    private static string GetId(DisplayObject displayObject, int index, ulong frame)
     {
         if(displayObject is DirectX11DisplayObjects.VfxDisplayObject vfx && !vfx.id.IsNullOrEmpty())
         {
             return vfx.id;
         }
 
-        return $"{displayObject.RenderEngineKind}:{P.FrameCounter}:{index}";
+        return $"{displayObject.RenderEngineKind}:{frame}:{index}";
     }
 
     private static uint GetDisplayStyleColor(DisplayStyle style)
@@ -181,64 +200,5 @@ internal static class ActiveDrawGeometrySnapshot
         return style.endFillColor;
     }
 
-    private static Point MakePoint(Vector3 point) => new()
-    {
-        x = point.X,
-        y = point.Y,
-        z = point.Z,
-    };
-
-    private static Point MakePoint(float x, float y, float z) => new()
-    {
-        x = x,
-        y = y,
-        z = z,
-    };
-
-    private static Point MakePointFromXzy(float x, float y, float z) => new()
-    {
-        x = x,
-        y = z,
-        z = y,
-    };
-
-    private sealed class Snapshot
-    {
-        public int version;
-        public uint frame;
-        public uint territoryId;
-        public long generatedAtTickMs;
-        public List<Item> items = [];
-    }
-
-    private sealed class Item
-    {
-        public string id;
-        public string source;
-        [JsonProperty("namespace")]
-        public string Namespace;
-        public string layout;
-        public string element;
-        public string kind;
-        public string renderEngine;
-        public uint color;
-        public Point center;
-        public Point start;
-        public Point end;
-        public float? radius;
-        public float? innerRadius;
-        public float? outerRadius;
-        public float? lineRadius;
-        public float? facingRad;
-        public float? halfAngleRad;
-        public float? angleMinRad;
-        public float? angleMaxRad;
-    }
-
-    private sealed class Point
-    {
-        public float x;
-        public float y;
-        public float z;
-    }
+    private static Vector3 FromXzy(float x, float y, float z) => new(x, z, y);
 }

--- a/Splatoon/Modules/ActiveDrawGeometrySnapshot.cs
+++ b/Splatoon/Modules/ActiveDrawGeometrySnapshot.cs
@@ -1,0 +1,244 @@
+﻿using Newtonsoft.Json;
+using Splatoon.RenderEngines.DirectX11;
+using Splatoon.RenderEngines.ImGuiLegacy;
+using Splatoon.Serializables;
+using Splatoon.Structures;
+
+namespace Splatoon.Modules;
+
+internal static class ActiveDrawGeometrySnapshot
+{
+    internal const int Version = 1;
+
+    internal static string BuildJson(List<DisplayObject> displayObjects)
+    {
+        var snapshot = new Snapshot()
+        {
+            version = Version,
+            frame = P.FrameCounter,
+            territoryId = Svc.ClientState.TerritoryType,
+            generatedAtTickMs = Environment.TickCount64,
+        };
+
+        for(var i = 0; i < displayObjects.Count; i++)
+        {
+            if(TryCreateItem(displayObjects[i], i, out var item))
+            {
+                snapshot.items.Add(item);
+            }
+        }
+
+        return JsonConvert.SerializeObject(snapshot, Formatting.None);
+    }
+
+    private static bool TryCreateItem(DisplayObject displayObject, int index, out Item item)
+    {
+        item = new()
+        {
+            id = GetId(displayObject, index),
+            source = "render",
+            Namespace = null,
+            layout = null,
+            element = null,
+            renderEngine = displayObject.RenderEngineKind.ToString(),
+            facingRad = null,
+            halfAngleRad = null,
+        };
+
+        if(displayObject is DirectX11DisplayObjects.DisplayObjectCircle dxCircle)
+        {
+            item.kind = "circle";
+            item.color = GetDisplayStyleColor(dxCircle.style);
+            item.center = MakePoint(dxCircle.origin);
+            item.radius = dxCircle.outerRadius;
+            return true;
+        }
+        if(displayObject is DirectX11DisplayObjects.DisplayObjectDonut dxDonut)
+        {
+            item.kind = "donut";
+            item.color = GetDisplayStyleColor(dxDonut.style);
+            item.center = MakePoint(dxDonut.origin);
+            item.innerRadius = dxDonut.innerRadius;
+            item.outerRadius = dxDonut.outerRadius;
+            item.radius = dxDonut.outerRadius;
+            return true;
+        }
+        if(displayObject is DirectX11DisplayObjects.DisplayObjectFan dxFan)
+        {
+            item.kind = "cone";
+            item.color = GetDisplayStyleColor(dxFan.style);
+            item.center = MakePoint(dxFan.origin);
+            item.innerRadius = dxFan.innerRadius;
+            item.outerRadius = dxFan.outerRadius;
+            item.radius = dxFan.outerRadius;
+            item.angleMinRad = dxFan.angleMin;
+            item.angleMaxRad = dxFan.angleMax;
+            return true;
+        }
+        if(displayObject is DirectX11DisplayObjects.DisplayObjectLine dxLine)
+        {
+            item.kind = "line";
+            item.color = dxLine.style.strokeColor;
+            item.start = MakePoint(dxLine.start);
+            item.end = MakePoint(dxLine.stop);
+            item.lineRadius = dxLine.radius;
+            item.radius = dxLine.radius;
+            return true;
+        }
+        if(displayObject is DirectX11DisplayObjects.DisplayObjectDot dxDot)
+        {
+            item.kind = "dot";
+            item.color = dxDot.color;
+            item.center = MakePoint(dxDot.x, dxDot.y, dxDot.z);
+            item.radius = dxDot.thickness;
+            return true;
+        }
+        if(displayObject is DirectX11DisplayObjects.DisplayObjectText dxText)
+        {
+            item.kind = "text";
+            item.color = dxText.fgcolor;
+            item.center = MakePointFromXzy(dxText.x, dxText.y, dxText.z);
+            return true;
+        }
+        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectDonut imDonut)
+        {
+            item.kind = "donut";
+            item.color = imDonut.color;
+            item.center = MakePointFromXzy(imDonut.x, imDonut.y, imDonut.z);
+            item.innerRadius = imDonut.radius;
+            item.outerRadius = imDonut.radius + imDonut.donut;
+            item.radius = item.outerRadius;
+            return true;
+        }
+        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectCircle imCircle)
+        {
+            item.kind = "circle";
+            item.color = imCircle.color;
+            item.center = MakePointFromXzy(imCircle.x, imCircle.y, imCircle.z);
+            item.radius = imCircle.radius;
+            return true;
+        }
+        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectCone imCone)
+        {
+            item.kind = "cone";
+            item.color = imCone.color;
+            item.center = MakePointFromXzy(imCone.x, imCone.y, imCone.z);
+            item.radius = imCone.radius;
+            item.outerRadius = imCone.radius;
+            item.angleMinRad = imCone.startRad;
+            item.angleMaxRad = imCone.endRad;
+            return true;
+        }
+        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectLine imLine)
+        {
+            item.kind = "line";
+            item.color = imLine.color;
+            item.start = MakePointFromXzy(imLine.ax, imLine.ay, imLine.az);
+            item.end = MakePointFromXzy(imLine.bx, imLine.by, imLine.bz);
+            item.lineRadius = 0f;
+            item.radius = 0f;
+            return true;
+        }
+        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectDot imDot)
+        {
+            item.kind = "dot";
+            item.color = imDot.color;
+            item.center = MakePointFromXzy(imDot.x, imDot.y, imDot.z);
+            item.radius = imDot.thickness;
+            return true;
+        }
+        if(displayObject is ImGuiLegacyDisplayObjects.DisplayObjectText imText)
+        {
+            item.kind = "text";
+            item.color = imText.fgcolor;
+            item.center = MakePointFromXzy(imText.x, imText.y, imText.z);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string GetId(DisplayObject displayObject, int index)
+    {
+        if(displayObject is DirectX11DisplayObjects.VfxDisplayObject vfx && !vfx.id.IsNullOrEmpty())
+        {
+            return vfx.id;
+        }
+
+        return $"{displayObject.RenderEngineKind}:{P.FrameCounter}:{index}";
+    }
+
+    private static uint GetDisplayStyleColor(DisplayStyle style)
+    {
+        if((style.strokeColor & 0xFF000000) != 0)
+        {
+            return style.strokeColor;
+        }
+        if((style.originFillColor & 0xFF000000) != 0)
+        {
+            return style.originFillColor;
+        }
+        return style.endFillColor;
+    }
+
+    private static Point MakePoint(Vector3 point) => new()
+    {
+        x = point.X,
+        y = point.Y,
+        z = point.Z,
+    };
+
+    private static Point MakePoint(float x, float y, float z) => new()
+    {
+        x = x,
+        y = y,
+        z = z,
+    };
+
+    private static Point MakePointFromXzy(float x, float y, float z) => new()
+    {
+        x = x,
+        y = z,
+        z = y,
+    };
+
+    private sealed class Snapshot
+    {
+        public int version;
+        public uint frame;
+        public uint territoryId;
+        public long generatedAtTickMs;
+        public List<Item> items = [];
+    }
+
+    private sealed class Item
+    {
+        public string id;
+        public string source;
+        [JsonProperty("namespace")]
+        public string Namespace;
+        public string layout;
+        public string element;
+        public string kind;
+        public string renderEngine;
+        public uint color;
+        public Point center;
+        public Point start;
+        public Point end;
+        public float? radius;
+        public float? innerRadius;
+        public float? outerRadius;
+        public float? lineRadius;
+        public float? facingRad;
+        public float? halfAngleRad;
+        public float? angleMinRad;
+        public float? angleMaxRad;
+    }
+
+    private sealed class Point
+    {
+        public float x;
+        public float y;
+        public float z;
+    }
+}

--- a/Splatoon/Modules/SplatoonIPC.cs
+++ b/Splatoon/Modules/SplatoonIPC.cs
@@ -1,26 +1,25 @@
-﻿namespace Splatoon.Modules;
+using Snapshot = (int version, uint frame, uint territoryId, long generatedAtTickMs, System.Collections.Generic.List<(string id, string source, string Namespace, string layout, string element, string kind, string renderEngine, uint color, System.Numerics.Vector3 center, System.Numerics.Vector3 start, System.Numerics.Vector3 end, float? radius, float? innerRadius, float? outerRadius, float? lineRadius, float? facingRad, float? halfAngleRad, float? angleMinRad, float? angleMaxRad)> items);
+
+namespace Splatoon.Modules;
 
 internal static class SplatoonIPC
 {
-    private static string activeDrawGeometryJson = "";
-
     internal static void Init()
     {
-        UpdateActiveDrawGeometrySnapshot();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.Loaded").SendMessage();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.IsLoaded").RegisterFunc(() => { return true; });
-        Svc.PluginInterface.GetIpcProvider<string>("Splatoon.GetActiveDrawGeometryV1").RegisterFunc(() => activeDrawGeometryJson);
+        Svc.PluginInterface.GetIpcProvider<Snapshot>("Splatoon.GetActiveDrawGeometryV1").RegisterFunc(GetActiveDrawGeometry);
     }
 
     internal static void Dispose()
     {
-        Svc.PluginInterface.GetIpcProvider<string>("Splatoon.GetActiveDrawGeometryV1").UnregisterFunc();
+        Svc.PluginInterface.GetIpcProvider<Snapshot>("Splatoon.GetActiveDrawGeometryV1").UnregisterFunc();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.IsLoaded").UnregisterFunc();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.Unloaded").SendMessage();
     }
 
-    internal static void UpdateActiveDrawGeometrySnapshot()
+    private static Snapshot GetActiveDrawGeometry()
     {
-        activeDrawGeometryJson = ActiveDrawGeometrySnapshot.BuildJson(S.RenderManager.GetUnifiedDisplayObjects());
+        return ActiveDrawGeometrySnapshot.Build(S.RenderManager.GetUnifiedDisplayObjects());
     }
 }

--- a/Splatoon/Modules/SplatoonIPC.cs
+++ b/Splatoon/Modules/SplatoonIPC.cs
@@ -2,15 +2,25 @@
 
 internal static class SplatoonIPC
 {
+    private static string activeDrawGeometryJson = "";
+
     internal static void Init()
     {
+        UpdateActiveDrawGeometrySnapshot();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.Loaded").SendMessage();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.IsLoaded").RegisterFunc(() => { return true; });
+        Svc.PluginInterface.GetIpcProvider<string>("Splatoon.GetActiveDrawGeometryV1").RegisterFunc(() => activeDrawGeometryJson);
     }
 
     internal static void Dispose()
     {
+        Svc.PluginInterface.GetIpcProvider<string>("Splatoon.GetActiveDrawGeometryV1").UnregisterFunc();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.IsLoaded").UnregisterFunc();
         Svc.PluginInterface.GetIpcProvider<bool>("Splatoon.Unloaded").SendMessage();
+    }
+
+    internal static void UpdateActiveDrawGeometrySnapshot()
+    {
+        activeDrawGeometryJson = ActiveDrawGeometrySnapshot.BuildJson(S.RenderManager.GetUnifiedDisplayObjects());
     }
 }

--- a/Splatoon/Splatoon.cs
+++ b/Splatoon/Splatoon.cs
@@ -641,6 +641,7 @@ public unsafe class Splatoon : IDalamudPlugin
             BuffEffectProcessor.ActorEffectUpdate();
             ScriptingProcessor.OnUpdate();
             CapturedPositions.Clear();
+            SplatoonIPC.UpdateActiveDrawGeometrySnapshot();
         }
         catch(Exception e)
         {

--- a/Splatoon/Splatoon.cs
+++ b/Splatoon/Splatoon.cs
@@ -641,7 +641,6 @@ public unsafe class Splatoon : IDalamudPlugin
             BuffEffectProcessor.ActorEffectUpdate();
             ScriptingProcessor.OnUpdate();
             CapturedPositions.Clear();
-            SplatoonIPC.UpdateActiveDrawGeometrySnapshot();
         }
         catch(Exception e)
         {


### PR DESCRIPTION
## Summary
  - Adds a new `Splatoon.GetActiveDrawGeometryV1` IPC provider that returns a JSON
  snapshot of the currently rendered display objects, letting other plugins read what
  Splatoon is drawing without hooking the render path.
  - Snapshot covers both render engines: DX11 (`circle`, `donut`, `fan`→`cone`, `line`,
   `dot`, `text`) and ImGui legacy equivalents. Each item carries id, source, kind,
  color, geometry (center/start/end, radii, angles), and the originating render engine.
  - Snapshot envelope includes `version` (1), `frame`, `territoryId`, and
  `generatedAtTickMs` so consumers can dedupe and detect zone changes.
  - Refreshed once per `Splatoon.Update` tick after `CapturedPositions.Clear()` so
  reads are non-blocking — the IPC just hands back the cached JSON string.
  
  ## Notes
  - ImGui legacy objects use `(x, y, z)` as `(x, height, z)`; the snapshot remaps them
  into world `(x, y, z)` for consistency with DX11 entries.
  - Coordinates for text/dot/line items use the explicit `MakePointFromXzy` helper to
  keep all output in the same axis convention.
  - `id` falls back to `{RenderEngine}:{frame}:{index}` when the underlying display
  object doesn't carry a stable identifier (only `VfxDisplayObject` currently does).
  
  ## Test plan
  - [ ] Load Splatoon, draw a few circles/cones/lines via existing layouts, and verify
  a consumer plugin sees the expected JSON via `Splatoon.GetActiveDrawGeometryV1`.
  - [ ] Confirm `version`, `frame`, `territoryId` advance as expected across zone
  changes.
  - [ ] Verify no measurable per-tick overhead with a heavy layout (many display
  objects).