### PR TITLE
Make InternationalString fallback null-safe and prefer English for unsupported languages

### DIFF
--- a/Splatoon/Serializables/InternationalString.cs
+++ b/Splatoon/Serializables/InternationalString.cs
@@ -22,11 +22,11 @@ public class InternationalString
 
     public InternationalString(string en = "", string jp = "", string de = "", string fr = "", string other = "")
     {
-        this.En = en;
-        this.Jp = jp;
-        this.De = de;
-        this.Fr = fr;
-        this.Other = other;
+        this.En = en ?? string.Empty;
+        this.Jp = jp ?? string.Empty;
+        this.De = de ?? string.Empty;
+        this.Fr = fr ?? string.Empty;
+        this.Other = other ?? string.Empty;
     }
 
     /// <summary>
@@ -46,52 +46,43 @@ public class InternationalString
 
     public string Get(string defaultString = "", ClientLanguage? language = null)
     {
-        string ret;
+        Normalize();
+        defaultString ??= string.Empty;
         language ??= Svc.Data.Language;
-        if(language == ClientLanguage.English)
+        var ret = language switch
         {
-            ret = En == string.Empty ? defaultString : En;
-        }
-        else if(language == ClientLanguage.Japanese)
-        {
-            ret = Jp == string.Empty ? defaultString : Jp;
-        }
-        else if(language == ClientLanguage.German)
-        {
-            ret = De == string.Empty ? defaultString : De;
-        }
-        else if(language == ClientLanguage.French)
-        {
-            ret = Fr == string.Empty ? defaultString : Fr;
-        }
-        else
-        {
-            ret = Other == string.Empty ? defaultString : Other;
-        }
-        if(ret == string.Empty)
-        {
-            if(En != string.Empty)
-            {
-                ret = En;
-            }
-            else if(Other != string.Empty)
-            {
-                ret = Other;
-            }
-            else if(Jp != string.Empty)
-            {
-                ret = Jp;
-            }
-            else if(De != string.Empty)
-            {
-                ret = De;
-            }
-            else if(Fr != string.Empty)
-            {
-                ret = Fr;
-            }
-        }
-        return ret;
+            ClientLanguage.English => En,
+            ClientLanguage.Japanese => Jp,
+            ClientLanguage.German => De,
+            ClientLanguage.French => Fr,
+            _ => Other
+        };
+
+        if(!ret.IsNullOrEmpty())
+            return ret;
+        if(!En.IsNullOrEmpty())
+            return En;
+        if(!defaultString.IsNullOrEmpty())
+            return defaultString;
+        if(!Other.IsNullOrEmpty())
+            return Other;
+        if(!Jp.IsNullOrEmpty())
+            return Jp;
+        if(!De.IsNullOrEmpty())
+            return De;
+        if(!Fr.IsNullOrEmpty())
+            return Fr;
+        return string.Empty;
+    }
+
+    private void Normalize()
+    {
+        guid ??= Guid.NewGuid().ToString();
+        En ??= string.Empty;
+        Jp ??= string.Empty;
+        De ??= string.Empty;
+        Fr ??= string.Empty;
+        Other ??= string.Empty;
     }
 
     internal ref string CurrentLangString
@@ -123,6 +114,8 @@ public class InternationalString
 
     public void ImGuiEdit(ref string DefaultValue, string helpMessage = null)
     {
+        Normalize();
+        DefaultValue ??= string.Empty;
         if(ImGui.BeginCombo($"##{guid}", Get(DefaultValue)))
         {
             ImGuiEx.LineCentered($"line{guid}", delegate
@@ -173,11 +166,13 @@ public class InternationalString
 
     public bool IsEmpty()
     {
+        Normalize();
         return En.IsNullOrEmpty() && Jp.IsNullOrEmpty() && De.IsNullOrEmpty() && Fr.IsNullOrEmpty() && Other.IsNullOrEmpty();
     }
 
     public ref string GetRefString(ClientLanguage language)
     {
+        Normalize();
         if(language == ClientLanguage.English) return ref En;
         else if(language == ClientLanguage.Japanese) return ref Jp;
         else if(language == ClientLanguage.German) return ref De;
@@ -187,6 +182,7 @@ public class InternationalString
 
     private void EditLangSpecificString(ClientLanguage language, ref string str)
     {
+        str ??= string.Empty;
         var col = false;
         if(str == string.Empty)
         {


### PR DESCRIPTION
## Summary

  This updates `InternationalString` so it never returns `null` from `Get()`, and so unsupported client languages fall
  back to English before using the generic default string.

## Motivation

  A CN client user reported a crash when a script settings UI called:

  ```csharp
  ImGui.TreeNode(C.PastFutureHeaderText.Get())
```

  For unsupported client languages, InternationalString.Get() uses Other. If an imported/deserialized config contains
  null string fields, Other can be null, and Get() can return null. Passing that into ImGui labels such as TreeNode can
  crash.

## Changes

  - Normalize En, Jp, De, Fr, Other, and guid when InternationalString is used.
  - Make the constructor null-safe.
  - Make Get() always return a non-null string.
  - Make ImGuiEdit(), IsEmpty(), GetRefString(), and language-specific editing paths tolerate null values.
  - Change fallback order to prefer English for unsupported or missing languages:

  current language -> English -> default string -> Other -> Japanese -> German -> French -> empty string

## Compatibility Notes

  For supported languages with a configured value, behavior should be unchanged.

  The main intentional behavior change is for missing/unsupported language values: English is now preferred before
  defaultString. This makes script/layout UI labels more predictable on CN and other unsupported clients, and avoids
  null or blank ImGui labels when English text exists.