### PR TITLE
Fix InternationalString default fallback order

### DIFF
--- a/Splatoon/Serializables/InternationalString.cs
+++ b/Splatoon/Serializables/InternationalString.cs
@@ -60,10 +60,10 @@ public class InternationalString
 
         if(!ret.IsNullOrEmpty())
             return ret;
-        if(!En.IsNullOrEmpty())
-            return En;
         if(!defaultString.IsNullOrEmpty())
             return defaultString;
+        if(!En.IsNullOrEmpty())
+            return En;
         if(!Other.IsNullOrEmpty())
             return Other;
         if(!Jp.IsNullOrEmpty())


### PR DESCRIPTION
## Summary

Restores the intended fallback priority in `InternationalString.Get()` so the default string is used before falling back to English when the current client language value is empty.

The resulting order is:

1. Current client language value
2. `defaultString`
3. English
4. Other
5. Japanese
6. German
7. French
8. `string.Empty`

## Root Cause

PR #418 fixed `InternationalString` null handling by normalizing nullable string fields, but it also changed the fallback order so `En` was returned before `defaultString`.

That can break existing layout triggers. Several existing presets store the Japanese trigger text in the default `Match` field, store English in `MatchIntl.En`, and leave `MatchIntl.Jp` empty. On a Japanese client, `MatchIntl.Get(Match)` would then return the English string instead of the Japanese default string, causing localized battle log matching to fail.

## Impact

This keeps the null-safety fix from PR #418 intact while restoring the previous default-string fallback behavior. In particular:

- `Normalize()` is still called before resolving the string.
- `defaultString ??= string.Empty` is still applied.
- `Get()` still never returns `null`.
- Existing layouts that rely on `Match` as the localized/default trigger string continue to work.

## Validation

- Reviewed the runtime trigger path using `MatchIntl.Get(t.Match)` in `LayoutUtils`.
- Confirmed existing presets contain the at-risk pattern: non-empty `Match`, non-empty `MatchIntl.En`, and empty `MatchIntl.Jp`.
- Ran `git diff --check` successfully.
- Ran `dotnet build Splatoon.sln` successfully. The build still emits existing warnings from the solution, but no errors were introduced by this change.
