### PR TITLE
Move P2 Trine near tank marker outward

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Trine_Beta.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Trine_Beta.cs
@@ -44,6 +44,7 @@ public class P2_Trine_Beta : SplatoonScript
     private const float PartyFinalSearchRadius = 4.0f;
     private const float PartyOutwardOffset = 2.0f;
     private const float PartyFinalOutwardOffset = 2.0f;
+    private const float TankNearFinalOutwardOffset = 1.5f;
     private const float TankNearSearchMaxRadius = 13.0f;
     private const float TankFarRadius = 17.0f;
     private const float OffTankFinalOutwardOffset = 2.0f;
@@ -92,7 +93,7 @@ public class P2_Trine_Beta : SplatoonScript
     private Vector3 _firstWavePartyDestination;
 
     public override HashSet<uint>? ValidTerritories { get; } = [TerritoryDancingMadUltimate];
-    public override Metadata Metadata => new(3, "Garume");
+    public override Metadata Metadata => new(4, "Garume");
 
     private Config C
     {
@@ -351,6 +352,9 @@ public class P2_Trine_Beta : SplatoonScript
             TrineExplosionClearance, 0.0f, TankNearSearchMaxRadius);
         mainTankDestination = RefineTankNearDestinationInward(mainTankDestination, centralTriangle.Center, direction,
             hazardPoints, TrineExplosionClearance);
+        mainTankDestination = MoveOutwardFromArenaCenter(mainTankDestination, TankNearFinalOutwardOffset);
+        mainTankDestination = AdjustPointAwayFromHazardPoints(mainTankDestination, hazardPoints, TrineExplosionClearance,
+            1.5f);
         var offTankDestination = AdjustPointAwayFromHazardPoints(centralTriangle.Center + direction * TankFarRadius,
             hazardPoints, TrineExplosionClearance, 1.5f);
         offTankDestination = MoveOutwardFromArenaCenter(offTankDestination, OffTankFinalOutwardOffset);

--- a/SplatoonScripts/update.csv
+++ b/SplatoonScripts/update.csv
@@ -203,7 +203,7 @@ SplaSim.SplatoonScripts.Duties.Dawntrail.DancingMadUltimate@P1_Wave_Cannon_Tower
 SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P1_Arrows,1,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P1_Arrows.cs
 SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P2_Forsaken_Fixed_Partner,6,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Fixed_Partner.cs
 SplaSim.SplatoonScripts.Duties.Dawntrail.DancingMadUltimate@P2_Forsaken_beta,7,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
-SplaSim.SplatoonScripts.Duties.Dawntrail.DancingMadUltimate@P2_Trine_Beta,3,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Trine_Beta.cs
+SplaSim.SplatoonScripts.Duties.Dawntrail.DancingMadUltimate@P2_Trine_Beta,4,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Trine_Beta.cs
 SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P1_Graven3_FinalSpread,3,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P1_Graven3_FinalSpread.cs
 SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P1_GravenImage_Reminder,3,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P1_GravenImage_Reminder.cs
 SplaSim.SplatoonScripts.Duties.Dawntrail.DancingMadUltimate@P1_Teletrouncing_Image3,1,https://github.com/PunishXIV/Splatoon/raw/main/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P1_Teletrouncing_Image3.cs


### PR DESCRIPTION
## Summary
- move the P2 Trine near-tank final marker 1.5m outward after the existing inward refinement
- re-run Trine hazard clearance after the outward adjustment
- bump P2_Trine_Beta metadata/update.csv version to 4

## Testing
- dotnet build SplatoonScripts\SplatoonScriptsOfficial.csproj --no-restore -v quiet -clp:ErrorsOnly