### PR TITLE
Add Forsaken marker command settings

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
@@ -54,7 +54,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private const float FinalAllThingsEndingOffset = 4f;
     private const float TowerOffsetCardinal = 8f;
     private const float TowerOffsetDiagonal = 5.7f;
-    private const int CurrentDefaultsVersion = 14;
+    private const int CurrentDefaultsVersion = 15;
 
     private static readonly Vector3[] TowerPositions =
     [
@@ -201,6 +201,20 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             "ONの場合、8回目の円/扇ランクを選択したマーカー種別から判定します。OFFの場合は従来通りデバフと優先順位で判定します。"
     };
 
+    private static readonly InternationalString UseLastKnownDebuffsText = new()
+    {
+        En = "Continue with last known debuffs",
+        Jp = "最後に確認したデバフで継続"
+    };
+
+    private static readonly InternationalString UseLastKnownDebuffsDescriptionText = new()
+    {
+        En =
+            "When the current status pattern is incomplete, retry assignment with the last observed Missing debuff for each player. This keeps guidance visible after deaths or incorrect tower soaks.",
+        Jp =
+            "現在ステータスのパターンが不完全な場合、各プレイヤーで最後に確認したミッシングデバフを使って再判定します。死亡や塔踏みミス後もナビを継続しやすくします。"
+    };
+
     private static readonly InternationalString CircleMarkerKindText = new()
     {
         En = "Circle marker type",
@@ -281,6 +295,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private readonly List<uint> _firstSetIds = [];
     private readonly List<uint> _secondSetIds = [];
     private readonly Dictionary<uint, LiveDebuffKind> _initialHeadPartnerDebuffs = [];
+    private readonly Dictionary<uint, LiveDebuffKind> _lastKnownDebuffs = [];
     private PatternInfo _lastPattern = new();
     private string _lastRuleLabel = "";
     private string _lastSelectorLabel = "";
@@ -316,7 +331,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private string _lastInstructionLog = "";
 
     public override HashSet<uint>? ValidTerritories { get; } = [TerritoryDancingMadUltimate];
-    public override Metadata Metadata => new(9, "Garume");
+    public override Metadata Metadata => new(10, "Garume");
 
     private new IPlayerCharacter BasePlayer => global::Splatoon.Splatoon.BasePlayer;
 
@@ -476,6 +491,8 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
         _active = true;
         var debuff = DebuffFromStatus(status.StatusId);
+        if (debuff != LiveDebuffKind.None)
+            _lastKnownDebuffs[sourceId] = debuff;
         DebugLogOnce(ref _lastCaptureBlockLog, $"status-{sourceId:X8}-{status.StatusId}", $"STATUS_GAIN missing source=0x{sourceId:X8} status={status.StatusId} debuff={debuff}");
         TryCaptureResolvingSets();
         if (debuff != LiveDebuffKind.None && _allowLiveContextRefresh)
@@ -883,6 +900,10 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         DrawMarkerCommandInput(FanMarkerCommandText.Get(), ref C.FanMarkerCommand);
 
         ImGui.Spacing();
+        ImGui.Checkbox(UseLastKnownDebuffsText.Get(), ref C.UseLastKnownDebuffs);
+        ImGui.TextWrapped(UseLastKnownDebuffsDescriptionText.Get());
+
+        ImGui.Spacing();
         ImGui.Checkbox(UseWave8MarkerResolutionText.Get(), ref C.UseWave8MarkerResolution);
         ImGui.TextWrapped(UseWave8MarkerResolutionDescriptionText.Get());
         if (C.UseWave8MarkerResolution)
@@ -1128,6 +1149,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         ImGui.TextUnformatted($"First set: {FormatResolvingSet(_firstSetIds)}");
         ImGui.TextUnformatted($"Second set: {FormatResolvingSet(_secondSetIds)}");
         ImGui.TextUnformatted($"Initial head partners: {FormatInitialHeadPartnerDebuffs()}");
+        ImGui.TextUnformatted($"Last known debuffs: {FormatLastKnownDebuffs()}");
         ImGui.TextUnformatted($"Pending spawns: {FormatMapPositionList(_pendingTowerSpawnPositions)}");
         ImGui.TextUnformatted($"Pending clears: {FormatMapPositionList(_pendingTowerClearPositions)}");
         ImGui.TextUnformatted($"Last pattern: H{_lastPattern.Head}/C{_lastPattern.Circle}/F{_lastPattern.Fan}");
@@ -1624,6 +1646,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             return false;
         }
 
+        RememberVisibleDebuffs(party);
         var resolvingGroup = GetGroupPlayers(wave.ResolvingGroup, party);
         if (resolvingGroup.Count == 0)
         {
@@ -1634,7 +1657,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
         var supportGroup = GetSupportGroup(wave.ResolvingGroup, party, resolvingGroup);
         var useWave8MarkerContext = HasCompleteWave8MarkerCoverage(resolvingGroup);
-        var pattern = BuildLivePattern(resolvingGroup, useWave8MarkerContext);
+        var pattern = BuildLivePattern(resolvingGroup, useWave8MarkerContext, out var useLastKnownDebuffContext);
         if (!HasConfiguredPattern(pattern))
         {
             failureReason = $"no configured pattern {FormatPattern(pattern)} wave={_currentWave} stage={_currentStage}";
@@ -1644,25 +1667,40 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         _stageContexts.Clear();
         foreach (var player in party)
         {
-            var context = BuildLiveContext(player, resolvingGroup, supportGroup, pattern, useWave8MarkerContext);
+            var context = BuildLiveContext(player, resolvingGroup, supportGroup, pattern, useWave8MarkerContext, useLastKnownDebuffContext);
             _stageContexts[player.EntityId] = context;
         }
 
         if (!_stageContexts.ContainsKey(currentPlayer.EntityId))
-            _stageContexts[currentPlayer.EntityId] = BuildLiveContext(currentPlayer, resolvingGroup, supportGroup, pattern, useWave8MarkerContext);
+            _stageContexts[currentPlayer.EntityId] = BuildLiveContext(currentPlayer, resolvingGroup, supportGroup, pattern, useWave8MarkerContext, useLastKnownDebuffContext);
 
         return _stageContexts.Count > 0;
     }
 
-    private PatternInfo BuildLivePattern(IReadOnlyList<IPlayerCharacter> resolvingGroup, bool useWave8MarkerContext)
+    private PatternInfo BuildLivePattern(
+        IReadOnlyList<IPlayerCharacter> resolvingGroup,
+        bool useWave8MarkerContext,
+        out bool useLastKnownDebuffContext)
     {
+        useLastKnownDebuffContext = false;
         var statusPattern = PatternInfo.FromPlayers(resolvingGroup);
-        if (!useWave8MarkerContext)
+        if (useWave8MarkerContext)
+        {
+            var markerPattern = PatternInfo.FromPlayers(resolvingGroup, Wave8MarkerEffectiveDebuff);
+            if (HasConfiguredPattern(markerPattern))
+                return markerPattern;
+        }
+
+        if (HasConfiguredPattern(statusPattern) || !C.UseLastKnownDebuffs)
             return statusPattern;
 
-        var markerPattern = PatternInfo.FromPlayers(resolvingGroup, Wave8MarkerEffectiveDebuff);
-        if (HasConfiguredPattern(markerPattern))
-            return markerPattern;
+        var fallbackPattern = PatternInfo.FromPlayers(resolvingGroup, LastKnownDebuffFromPlayer);
+        if (HasConfiguredPattern(fallbackPattern))
+        {
+            useLastKnownDebuffContext = true;
+            DebugLog($"LAST_KNOWN_DEBUFF_PATTERN wave={_currentWave} stage={_currentStage} current={FormatPattern(statusPattern)} fallback={FormatPattern(fallbackPattern)}");
+            return fallbackPattern;
+        }
 
         return statusPattern;
     }
@@ -1672,7 +1710,8 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         IReadOnlyList<IPlayerCharacter> resolvingGroup,
         IReadOnlyList<IPlayerCharacter> supportGroup,
         PatternInfo pattern,
-        bool useWave8MarkerContext)
+        bool useWave8MarkerContext,
+        bool useLastKnownDebuffContext)
     {
         var side = resolvingGroup.Any(p => p.EntityId == me.EntityId)
             ? ParticipantSide.ResolvingGroup
@@ -1681,9 +1720,9 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                 : ParticipantSide.Any;
 
         var sideGroup = side == ParticipantSide.SupportGroup ? supportGroup : resolvingGroup;
-        var debuff = DebuffForLiveContext(me, side, useWave8MarkerContext);
+        var debuff = DebuffForLiveContext(me, side, useWave8MarkerContext, useLastKnownDebuffContext);
         var sameDebuffPlayers = sideGroup
-            .Where(player => DebuffForLiveContext(player, side, useWave8MarkerContext) == debuff)
+            .Where(player => DebuffForLiveContext(player, side, useWave8MarkerContext, useLastKnownDebuffContext) == debuff)
             .ToList();
         var debuffIndex = sameDebuffPlayers.FindIndex(player => player.EntityId == me.EntityId);
         var debuffRank = debuff == LiveDebuffKind.None || debuffIndex < 0 ? 0 : debuffIndex + 1;
@@ -1701,12 +1740,38 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             pattern);
     }
 
-    private LiveDebuffKind DebuffForLiveContext(IPlayerCharacter player, ParticipantSide side, bool useWave8MarkerContext)
+    private LiveDebuffKind DebuffForLiveContext(
+        IPlayerCharacter player,
+        ParticipantSide side,
+        bool useWave8MarkerContext,
+        bool useLastKnownDebuffContext)
     {
         if (side == ParticipantSide.ResolvingGroup && useWave8MarkerContext)
             return Wave8MarkerEffectiveDebuff(player);
 
+        if (useLastKnownDebuffContext)
+            return LastKnownDebuffFromPlayer(player);
+
         return CurrentDebuffFromPlayer(player);
+    }
+
+    private void RememberVisibleDebuffs(IEnumerable<IPlayerCharacter> players)
+    {
+        foreach (var player in players)
+        {
+            var debuff = CurrentDebuffFromPlayer(player);
+            if (debuff != LiveDebuffKind.None)
+                _lastKnownDebuffs[player.EntityId] = debuff;
+        }
+    }
+
+    private LiveDebuffKind LastKnownDebuffFromPlayer(IPlayerCharacter player)
+    {
+        var current = CurrentDebuffFromPlayer(player);
+        if (current != LiveDebuffKind.None)
+            return current;
+
+        return _lastKnownDebuffs.GetValueOrDefault(player.EntityId, LiveDebuffKind.None);
     }
 
     private LiveDebuffKind Wave8MarkerEffectiveDebuff(IPlayerCharacter player)
@@ -2593,7 +2658,9 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
     private string DebugPlayer(IPlayerCharacter player)
     {
-        return $"{player.Name}(0x{player.EntityId:X8},{CurrentDebuffFromPlayer(player)})";
+        var current = CurrentDebuffFromPlayer(player);
+        var known = _lastKnownDebuffs.GetValueOrDefault(player.EntityId, LiveDebuffKind.None);
+        return $"{player.Name}(0x{player.EntityId:X8},{current},known={known})";
     }
 
     private static string DebugIdentity(IPlayerCharacter player)
@@ -2612,6 +2679,17 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             .OfType<IPlayerCharacter>()
             .ToDictionary(player => player.EntityId, player => player.Name.ToString());
         return string.Join(", ", _initialHeadPartnerDebuffs.Select(item =>
+            $"{players.GetValueOrDefault(item.Key, $"0x{item.Key:X8}")}:{item.Value}"));
+    }
+
+    private string FormatLastKnownDebuffs()
+    {
+        if (_lastKnownDebuffs.Count == 0) return "none";
+
+        var players = Controller.GetPartyMembers()
+            .OfType<IPlayerCharacter>()
+            .ToDictionary(player => player.EntityId, player => player.Name.ToString());
+        return string.Join(", ", _lastKnownDebuffs.Select(item =>
             $"{players.GetValueOrDefault(item.Key, $"0x{item.Key:X8}")}:{item.Value}"));
     }
 
@@ -2709,6 +2787,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         _firstSetIds.Clear();
         _secondSetIds.Clear();
         _initialHeadPartnerDebuffs.Clear();
+        _lastKnownDebuffs.Clear();
         _lastPattern = new PatternInfo();
         _lastRuleLabel = "";
         _lastDebuff = LiveDebuffKind.Any;
@@ -3260,6 +3339,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
         public bool EnableLiveMarkerCommands;
         public bool UseWave8MarkerResolution;
+        public bool UseLastKnownDebuffs = true;
         public string CircleMarkerCommand = "/mk stop <me>";
         public string FanMarkerCommand = "/mk bind <me>";
         public P2_Forsaken_beta.MarkerResolveKind CircleMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Stop;
@@ -3601,6 +3681,12 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                 CircleMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Stop;
                 FanMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Bind;
                 DefaultsVersion = 14;
+            }
+
+            if (DefaultsVersion < 15)
+            {
+                UseLastKnownDebuffs = true;
+                DefaultsVersion = 15;
             }
 
             for (var i = 0; i < Waves.Length; i++)

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
+using ECommons.Automation;
 using ECommons;
 using ECommons.Configuration;
+using ECommons.DalamudServices;
 using ECommons.GameFunctions;
 using ECommons.Hooks;
 using ECommons.Hooks.ActionEffectTypes;
@@ -13,6 +16,7 @@ using ECommons.ImGuiMethods;
 using ECommons.Logging;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using Splatoon;
+using Splatoon.Memory;
 using Splatoon.SplatoonScripting;
 using Splatoon.SplatoonScripting.Priority;
 
@@ -39,12 +43,18 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private const int BasicStageCount = 1;
     private const int PairCount = 4;
     private const int PreviewElementCount = 64;
+    private const uint MarkerIndexAttack1 = 0;
+    private const uint MarkerIndexAttack2 = 1;
+    private const uint MarkerIndexBind1 = 5;
+    private const uint MarkerIndexBind2 = 6;
+    private const uint MarkerIndexStop1 = 8;
+    private const uint MarkerIndexStop2 = 9;
     private const string PreviewElementPrefix = "Preview";
     private static readonly Vector3 ArenaCenter = new(100f, 0f, 100f);
     private const float FinalAllThingsEndingOffset = 4f;
     private const float TowerOffsetCardinal = 8f;
     private const float TowerOffsetDiagonal = 5.7f;
-    private const int CurrentDefaultsVersion = 13;
+    private const int CurrentDefaultsVersion = 14;
 
     private static readonly Vector3[] TowerPositions =
     [
@@ -137,6 +147,72 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             "4ペアすべてがPTに一致する場合、優先順位ペアより明示ペアを優先します。頭割りを含むペアごと1/2/3/8回目を処理する戦略では、ペア分割をOFFのまま使います。"
     };
 
+    private static readonly InternationalString MarkerSettingsHeaderText = new()
+    {
+        En = "Marker commands",
+        Jp = "マーカーコマンド"
+    };
+
+    private static readonly InternationalString MarkerSettingsDescriptionText = new()
+    {
+        En =
+            "After wave 3, first-set circle/fan players can self-mark for wave 8. Live command execution is opt-in; duty replay only logs the intended command.",
+        Jp =
+            "3回目塔処理後、前半セットの円/扇担当が8回目用に自分へマーカーを付けます。実戦でのコマンド実行は明示的にONにした場合のみで、リプレイ中は予定コマンドをログに出すだけです。"
+    };
+
+    private static readonly InternationalString EnableLiveMarkerCommandsText = new()
+    {
+        En = "Execute marker commands in live duty",
+        Jp = "実戦でマーカーコマンドを実行"
+    };
+
+    private static readonly InternationalString EnableLiveMarkerCommandsDescriptionText = new()
+    {
+        En =
+            "Off: print the command locally instead of sending it. On: send the configured command only outside duty recorder playback.",
+        Jp =
+            "OFF: コマンドは送信せずローカルログに表示します。ON: Duty Recorder以外の実戦中だけ設定コマンドを送信します。"
+    };
+
+    private static readonly InternationalString CircleMarkerCommandText = new()
+    {
+        En = "Circle command",
+        Jp = "円コマンド"
+    };
+
+    private static readonly InternationalString FanMarkerCommandText = new()
+    {
+        En = "Fan command",
+        Jp = "扇コマンド"
+    };
+
+    private static readonly InternationalString UseWave8MarkerResolutionText = new()
+    {
+        En = "Use markers for wave 8 resolution",
+        Jp = "8回目をマーカー基準で判定"
+    };
+
+    private static readonly InternationalString UseWave8MarkerResolutionDescriptionText = new()
+    {
+        En =
+            "When enabled, wave 8 circle/fan rank can be resolved from the selected marker family. When disabled, the existing debuff and priority logic is unchanged.",
+        Jp =
+            "ONの場合、8回目の円/扇ランクを選択したマーカー種別から判定します。OFFの場合は従来通りデバフと優先順位で判定します。"
+    };
+
+    private static readonly InternationalString CircleMarkerKindText = new()
+    {
+        En = "Circle marker type",
+        Jp = "円の読取マーカー"
+    };
+
+    private static readonly InternationalString FanMarkerKindText = new()
+    {
+        En = "Fan marker type",
+        Jp = "扇の読取マーカー"
+    };
+
     private static readonly InternationalString SplitHeadStackPairsText = new()
     {
         En = "Split head-stack pairs",
@@ -170,6 +246,14 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         new() { En = "Partner debuff", Jp = "相方デバフ" },
         new() { En = "Priority order", Jp = "優先順位" },
         new() { En = "Role side", Jp = "ロール側" }
+    ];
+
+    private static readonly InternationalString[] MarkerResolveKindLabelTexts =
+    [
+        new() { En = "None", Jp = "なし" },
+        new() { En = "Attack", Jp = "Attack" },
+        new() { En = "Stop", Jp = "Stop" },
+        new() { En = "Bind", Jp = "Bind" }
     ];
 
     private static readonly InternationalString PairHeaderText = new()
@@ -219,6 +303,8 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private bool _waitingForLiveDebuffRefresh;
     private int _waitingForLiveDebuffRefreshWave;
     private bool _finalAllThingsEndingCastSeen;
+    private bool _wave4SelfMarkerHandled;
+    private string _lastWave4SelfMarkerState = "";
     private string _currentInstruction = "";
     private bool _hasDestination;
     private Vector3 _myDestination = Vector3.Zero;
@@ -230,7 +316,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private string _lastInstructionLog = "";
 
     public override HashSet<uint>? ValidTerritories { get; } = [TerritoryDancingMadUltimate];
-    public override Metadata Metadata => new(8, "Garume");
+    public override Metadata Metadata => new(9, "Garume");
 
     private new IPlayerCharacter BasePlayer => global::Splatoon.Splatoon.BasePlayer;
 
@@ -443,6 +529,9 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         if (_active)
             TryCaptureResolvingSets();
 
+        if (_active)
+            TryRunWave4SelfMarker();
+
         if (_active && _hasStage)
             UpdateStageInstruction();
 
@@ -480,6 +569,13 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             ImGui.Indent();
             ImGui.TextWrapped(WaveTableDescriptionText.Get());
             DrawWaveSettings();
+            ImGui.Unindent();
+        }
+
+        if (ImGui.CollapsingHeader(MarkerSettingsHeaderText.Get(), ImGuiTreeNodeFlags.DefaultOpen))
+        {
+            ImGui.Indent();
+            DrawMarkerSettings();
             ImGui.Unindent();
         }
 
@@ -777,6 +873,43 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         }
     }
 
+    private void DrawMarkerSettings()
+    {
+        ImGui.TextWrapped(MarkerSettingsDescriptionText.Get());
+        ImGui.Checkbox(EnableLiveMarkerCommandsText.Get(), ref C.EnableLiveMarkerCommands);
+        ImGui.TextWrapped(EnableLiveMarkerCommandsDescriptionText.Get());
+
+        DrawMarkerCommandInput(CircleMarkerCommandText.Get(), ref C.CircleMarkerCommand);
+        DrawMarkerCommandInput(FanMarkerCommandText.Get(), ref C.FanMarkerCommand);
+
+        ImGui.Spacing();
+        ImGui.Checkbox(UseWave8MarkerResolutionText.Get(), ref C.UseWave8MarkerResolution);
+        ImGui.TextWrapped(UseWave8MarkerResolutionDescriptionText.Get());
+        if (C.UseWave8MarkerResolution)
+        {
+            DrawMarkerResolveKindCombo(CircleMarkerKindText.Get(), ref C.CircleMarkerKind);
+            DrawMarkerResolveKindCombo(FanMarkerKindText.Get(), ref C.FanMarkerKind);
+        }
+    }
+
+    private static void DrawMarkerCommandInput(string label, ref string command)
+    {
+        command ??= "";
+        ImGui.SetNextItemWidth(-1f);
+        ImGui.InputText(label, ref command, 160);
+    }
+
+    private static void DrawMarkerResolveKindCombo(string label, ref MarkerResolveKind kind)
+    {
+        var index = (int)kind;
+        if (index < 0 || index >= MarkerResolveKindLabelTexts.Length)
+            index = 0;
+
+        ImGui.SetNextItemWidth(200f);
+        if (ImGui.Combo(label, ref index, BuildMarkerResolveKindLabels(), MarkerResolveKindLabelTexts.Length))
+            kind = (MarkerResolveKind)Math.Clamp(index, 0, MarkerResolveKindLabelTexts.Length - 1);
+    }
+
     private void DrawBasicPositionSettings()
     {
         if (ImGui.TreeNode(C.PastFutureHeaderText.Get()))
@@ -1004,6 +1137,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         ImGui.TextUnformatted($"Last selector: {(_lastSelectorLabel.Length == 0 ? "none" : _lastSelectorLabel)}");
         ImGui.TextUnformatted($"Last matched rule: {_lastRuleLabel}");
         ImGui.TextUnformatted($"Context cache: {_stageContexts.Count} players");
+        ImGui.TextUnformatted($"Wave 4 self marker: {(_wave4SelfMarkerHandled ? "handled" : "pending")} {(_lastWave4SelfMarkerState.Length == 0 ? "" : _lastWave4SelfMarkerState)}");
 
         var overrideName = global::Splatoon.Splatoon.BasePlayerOverride;
         var local = global::ECommons.DalamudServices.Svc.Objects.LocalPlayer;
@@ -1143,6 +1277,91 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         DebugLog($"ACTIVATE_TOWER wave={wave} stage={stage} reference={FormatMapPosition(reference)} group={C.Waves[Math.Clamp(wave, 1, WaveCount) - 1].ResolvingGroup} liveRefresh={_allowLiveContextRefresh} waitDebuffRefresh={_waitingForLiveDebuffRefresh}");
         UpdateStageInstruction();
         ApplyDisplay();
+    }
+
+    private void TryRunWave4SelfMarker()
+    {
+        if (_wave4SelfMarkerHandled)
+            return;
+
+        if (!_hasStage || _currentWave < 4)
+            return;
+
+        if (_currentWave > 4 || _currentStage != StageKind.Tower)
+        {
+            _wave4SelfMarkerHandled = true;
+            _lastWave4SelfMarkerState = "skipped: wave 4 tower window passed";
+            DebugLog($"WAVE4_MARKER {_lastWave4SelfMarkerState}");
+            return;
+        }
+
+        if (_firstSetIds.Count == 0)
+        {
+            _lastWave4SelfMarkerState = "waiting: first set unresolved";
+            return;
+        }
+
+        var me = BasePlayer;
+        if (me == null)
+        {
+            _lastWave4SelfMarkerState = "waiting: base player unresolved";
+            return;
+        }
+
+        if (!_firstSetIds.Contains(me.EntityId))
+        {
+            _wave4SelfMarkerHandled = true;
+            _lastWave4SelfMarkerState = "skipped: player is not in first set";
+            DebugLog($"WAVE4_MARKER {_lastWave4SelfMarkerState} player=0x{me.EntityId:X8}");
+            return;
+        }
+
+        var debuff = CurrentDebuffFromPlayer(me);
+        var command = debuff switch
+        {
+            LiveDebuffKind.Circle => C.CircleMarkerCommand,
+            LiveDebuffKind.Fan => C.FanMarkerCommand,
+            _ => null
+        };
+
+        if (command == null)
+        {
+            _lastWave4SelfMarkerState = $"waiting: debuff is {debuff}";
+            return;
+        }
+
+        command = command.Trim();
+        if (command.Length == 0)
+        {
+            _wave4SelfMarkerHandled = true;
+            _lastWave4SelfMarkerState = $"skipped: {debuff} marker command is empty";
+            DebugLog($"WAVE4_MARKER {_lastWave4SelfMarkerState}");
+            return;
+        }
+
+        _wave4SelfMarkerHandled = true;
+        RunWave4MarkerCommand(command, debuff);
+    }
+
+    private void RunWave4MarkerCommand(string command, LiveDebuffKind debuff)
+    {
+        if (Svc.Condition[ConditionFlag.DutyRecorderPlayback])
+        {
+            _lastWave4SelfMarkerState = $"replay log: {command}";
+            DuoLog.Information($"[DMU P2 Forsaken beta] Wave 4 self marker for {debuff}: {command} (suppressed in duty recorder playback)");
+        }
+        else if (!C.EnableLiveMarkerCommands)
+        {
+            _lastWave4SelfMarkerState = $"dry run: {command}";
+            DuoLog.Information($"[DMU P2 Forsaken beta] Wave 4 self marker for {debuff}: {command} (not sent; enable marker commands in settings to execute it)");
+        }
+        else
+        {
+            _lastWave4SelfMarkerState = $"sent: {command}";
+            Chat.ExecuteCommand(command);
+        }
+
+        DebugLog($"WAVE4_MARKER state=\"{_lastWave4SelfMarkerState}\" debuff={debuff} liveEnabled={C.EnableLiveMarkerCommands} replay={Svc.Condition[ConditionFlag.DutyRecorderPlayback]}");
     }
 
     private static void AddUniquePairPosition(List<uint> list, uint position)
@@ -1414,7 +1633,8 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         }
 
         var supportGroup = GetSupportGroup(wave.ResolvingGroup, party, resolvingGroup);
-        var pattern = PatternInfo.FromPlayers(resolvingGroup);
+        var useWave8MarkerContext = HasCompleteWave8MarkerCoverage(resolvingGroup);
+        var pattern = BuildLivePattern(resolvingGroup, useWave8MarkerContext);
         if (!HasConfiguredPattern(pattern))
         {
             failureReason = $"no configured pattern {FormatPattern(pattern)} wave={_currentWave} stage={_currentStage}";
@@ -1424,21 +1644,35 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         _stageContexts.Clear();
         foreach (var player in party)
         {
-            var context = BuildLiveContext(player, resolvingGroup, supportGroup, pattern);
+            var context = BuildLiveContext(player, resolvingGroup, supportGroup, pattern, useWave8MarkerContext);
             _stageContexts[player.EntityId] = context;
         }
 
         if (!_stageContexts.ContainsKey(currentPlayer.EntityId))
-            _stageContexts[currentPlayer.EntityId] = BuildLiveContext(currentPlayer, resolvingGroup, supportGroup, pattern);
+            _stageContexts[currentPlayer.EntityId] = BuildLiveContext(currentPlayer, resolvingGroup, supportGroup, pattern, useWave8MarkerContext);
 
         return _stageContexts.Count > 0;
+    }
+
+    private PatternInfo BuildLivePattern(IReadOnlyList<IPlayerCharacter> resolvingGroup, bool useWave8MarkerContext)
+    {
+        var statusPattern = PatternInfo.FromPlayers(resolvingGroup);
+        if (!useWave8MarkerContext)
+            return statusPattern;
+
+        var markerPattern = PatternInfo.FromPlayers(resolvingGroup, Wave8MarkerEffectiveDebuff);
+        if (HasConfiguredPattern(markerPattern))
+            return markerPattern;
+
+        return statusPattern;
     }
 
     private LiveContext BuildLiveContext(
         IPlayerCharacter me,
         IReadOnlyList<IPlayerCharacter> resolvingGroup,
         IReadOnlyList<IPlayerCharacter> supportGroup,
-        PatternInfo pattern)
+        PatternInfo pattern,
+        bool useWave8MarkerContext)
     {
         var side = resolvingGroup.Any(p => p.EntityId == me.EntityId)
             ? ParticipantSide.ResolvingGroup
@@ -1447,13 +1681,14 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                 : ParticipantSide.Any;
 
         var sideGroup = side == ParticipantSide.SupportGroup ? supportGroup : resolvingGroup;
-        var debuff = CurrentDebuffFromPlayer(me);
+        var debuff = DebuffForLiveContext(me, side, useWave8MarkerContext);
         var sameDebuffPlayers = sideGroup
-            .Where(player => CurrentDebuffFromPlayer(player) == debuff)
+            .Where(player => DebuffForLiveContext(player, side, useWave8MarkerContext) == debuff)
             .ToList();
         var debuffIndex = sameDebuffPlayers.FindIndex(player => player.EntityId == me.EntityId);
         var debuffRank = debuff == LiveDebuffKind.None || debuffIndex < 0 ? 0 : debuffIndex + 1;
         debuffRank = AdjustInitialHeadRankFromExplicitPair(me, side, debuff, debuffRank);
+        debuffRank = AdjustWave8MarkerRank(me, side, debuff, debuffRank, useWave8MarkerContext);
         var supportRank = side == ParticipantSide.SupportGroup
             ? IndexOfPlayer(supportGroup, me.EntityId) + 1
             : 0;
@@ -1464,6 +1699,103 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             debuffRank,
             supportRank,
             pattern);
+    }
+
+    private LiveDebuffKind DebuffForLiveContext(IPlayerCharacter player, ParticipantSide side, bool useWave8MarkerContext)
+    {
+        if (side == ParticipantSide.ResolvingGroup && useWave8MarkerContext)
+            return Wave8MarkerEffectiveDebuff(player);
+
+        return CurrentDebuffFromPlayer(player);
+    }
+
+    private LiveDebuffKind Wave8MarkerEffectiveDebuff(IPlayerCharacter player)
+    {
+        var current = CurrentDebuffFromPlayer(player);
+        var circleMarker = HasMarkerKind(player, C.CircleMarkerKind);
+        var fanMarker = HasMarkerKind(player, C.FanMarkerKind);
+
+        return (circleMarker, fanMarker) switch
+        {
+            (true, false) => LiveDebuffKind.Circle,
+            (false, true) => LiveDebuffKind.Fan,
+            _ => current
+        };
+    }
+
+    private int AdjustWave8MarkerRank(
+        IPlayerCharacter player,
+        ParticipantSide side,
+        LiveDebuffKind debuff,
+        int currentRank,
+        bool useWave8MarkerContext)
+    {
+        if (side != ParticipantSide.ResolvingGroup || !useWave8MarkerContext)
+            return currentRank;
+
+        var markerKind = debuff switch
+        {
+            LiveDebuffKind.Circle => C.CircleMarkerKind,
+            LiveDebuffKind.Fan => C.FanMarkerKind,
+            _ => MarkerResolveKind.None
+        };
+
+        if (!TryGetMarkerPriorityIndices(markerKind, out var priority1, out var priority2))
+            return currentRank;
+
+        if (Marking.HaveMark(player, priority1))
+            return 1;
+        if (Marking.HaveMark(player, priority2))
+            return 2;
+
+        return currentRank;
+    }
+
+    private bool ShouldUseWave8MarkerResolution()
+    {
+        return C.UseWave8MarkerResolution && _currentWave == WaveCount;
+    }
+
+    private bool HasCompleteWave8MarkerCoverage(IReadOnlyList<IPlayerCharacter> resolvingGroup)
+    {
+        return ShouldUseWave8MarkerResolution() && resolvingGroup.Count > 0 &&
+               resolvingGroup.All(HasExactlyOneWave8MarkerKind);
+    }
+
+    private bool HasExactlyOneWave8MarkerKind(IPlayerCharacter player)
+    {
+        var circleMarker = HasMarkerKind(player, C.CircleMarkerKind);
+        var fanMarker = HasMarkerKind(player, C.FanMarkerKind);
+        return circleMarker != fanMarker;
+    }
+
+    private static bool HasMarkerKind(IPlayerCharacter player, MarkerResolveKind kind)
+    {
+        return TryGetMarkerPriorityIndices(kind, out var priority1, out var priority2) &&
+               (Marking.HaveMark(player, priority1) || Marking.HaveMark(player, priority2));
+    }
+
+    private static bool TryGetMarkerPriorityIndices(MarkerResolveKind kind, out uint priority1, out uint priority2)
+    {
+        switch (kind)
+        {
+            case MarkerResolveKind.Attack:
+                priority1 = MarkerIndexAttack1;
+                priority2 = MarkerIndexAttack2;
+                return true;
+            case MarkerResolveKind.Stop:
+                priority1 = MarkerIndexStop1;
+                priority2 = MarkerIndexStop2;
+                return true;
+            case MarkerResolveKind.Bind:
+                priority1 = MarkerIndexBind1;
+                priority2 = MarkerIndexBind2;
+                return true;
+            default:
+                priority1 = 0;
+                priority2 = 0;
+                return false;
+        }
     }
 
     private static int IndexOfPlayer(IReadOnlyList<IPlayerCharacter> players, uint entityId)
@@ -2145,6 +2477,11 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         return InitialHeadStackRankModeLabelTexts.Select(item => item.Get()).ToArray();
     }
 
+    private static string[] BuildMarkerResolveKindLabels()
+    {
+        return MarkerResolveKindLabelTexts.Select(item => item.Get()).ToArray();
+    }
+
     private string BasicStageLabel(BasicStageKind stage)
     {
         return stage switch
@@ -2362,6 +2699,8 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         _waitingForLiveDebuffRefresh = false;
         _waitingForLiveDebuffRefreshWave = 0;
         _finalAllThingsEndingCastSeen = false;
+        _wave4SelfMarkerHandled = false;
+        _lastWave4SelfMarkerState = "";
         _currentInstruction = "";
         _hasDestination = false;
         _myDestination = Vector3.Zero;
@@ -2495,6 +2834,14 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         RoleSide
     }
 
+    public enum MarkerResolveKind
+    {
+        None,
+        Attack,
+        Stop,
+        Bind
+    }
+
     public enum BasicStageKind
     {
         Tower
@@ -2577,12 +2924,15 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                    (Fan < 0 || Fan == actual.Fan);
         }
 
-        public static PatternInfo FromPlayers(IEnumerable<IPlayerCharacter> players)
+        public static PatternInfo FromPlayers(
+            IEnumerable<IPlayerCharacter> players,
+            Func<IPlayerCharacter, LiveDebuffKind>? debuffSelector = null)
         {
             var info = new PatternInfo(0, 0, 0);
             foreach (var player in players)
             {
-                switch (CurrentDebuffFromPlayer(player))
+                var debuff = debuffSelector?.Invoke(player) ?? CurrentDebuffFromPlayer(player);
+                switch (debuff)
                 {
                     case LiveDebuffKind.HeadStack:
                         info.Head++;
@@ -2908,6 +3258,13 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         public bool ShowFinalAllThingsEndingPastText = true;
         public bool ShowFinalAllThingsEndingFutureText = true;
 
+        public bool EnableLiveMarkerCommands;
+        public bool UseWave8MarkerResolution;
+        public string CircleMarkerCommand = "/mk stop <me>";
+        public string FanMarkerCommand = "/mk bind <me>";
+        public P2_Forsaken_beta.MarkerResolveKind CircleMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Stop;
+        public P2_Forsaken_beta.MarkerResolveKind FanMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Bind;
+
         public InternationalString EastLabelText = new()
         {
             En = "E",
@@ -3134,6 +3491,10 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             FinalAllThingsEndingGatherNorthText ??= new InternationalString { En = "North stack", Jp = "北集合" };
             FinalAllThingsEndingPastText ??= new InternationalString { En = "North", Jp = "北" };
             FinalAllThingsEndingFutureText ??= new InternationalString { En = "South", Jp = "南" };
+            CircleMarkerCommand ??= "/mk stop <me>";
+            FanMarkerCommand ??= "/mk bind <me>";
+            CircleMarkerKind = ClampMarkerResolveKind(CircleMarkerKind);
+            FanMarkerKind = ClampMarkerResolveKind(FanMarkerKind);
             PastFixedPosition ??= new PositionRule(PositionBasis.ArenaCenter, 45f, 4f);
             FutureFixedPosition ??= new PositionRule(PositionBasis.ArenaCenter, 225f, 4f);
             PastFixedPosition.Ensure();
@@ -3233,6 +3594,15 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                 DefaultsVersion = 13;
             }
 
+            if (DefaultsVersion < 14)
+            {
+                CircleMarkerCommand ??= "/mk stop <me>";
+                FanMarkerCommand ??= "/mk bind <me>";
+                CircleMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Stop;
+                FanMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Bind;
+                DefaultsVersion = 14;
+            }
+
             for (var i = 0; i < Waves.Length; i++)
             {
                 Waves[i] ??= new WaveConfig();
@@ -3242,6 +3612,11 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             PreviewWave = Math.Clamp(PreviewWave, 1, WaveCount);
             if ((int)PreviewStage < 0 || (int)PreviewStage >= StageCount)
                 PreviewStage = StageKind.Tower;
+        }
+
+        private static P2_Forsaken_beta.MarkerResolveKind ClampMarkerResolveKind(P2_Forsaken_beta.MarkerResolveKind kind)
+        {
+            return Enum.IsDefined(kind) ? kind : P2_Forsaken_beta.MarkerResolveKind.None;
         }
 
         private void MigrateUiTerminology()

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_beta.cs
@@ -54,7 +54,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private const float FinalAllThingsEndingOffset = 4f;
     private const float TowerOffsetCardinal = 8f;
     private const float TowerOffsetDiagonal = 5.7f;
-    private const int CurrentDefaultsVersion = 15;
+    private const int CurrentDefaultsVersion = 14;
 
     private static readonly Vector3[] TowerPositions =
     [
@@ -201,20 +201,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             "ONの場合、8回目の円/扇ランクを選択したマーカー種別から判定します。OFFの場合は従来通りデバフと優先順位で判定します。"
     };
 
-    private static readonly InternationalString UseLastKnownDebuffsText = new()
-    {
-        En = "Continue with last known debuffs",
-        Jp = "最後に確認したデバフで継続"
-    };
-
-    private static readonly InternationalString UseLastKnownDebuffsDescriptionText = new()
-    {
-        En =
-            "When the current status pattern is incomplete, retry assignment with the last observed Missing debuff for each player. This keeps guidance visible after deaths or incorrect tower soaks.",
-        Jp =
-            "現在ステータスのパターンが不完全な場合、各プレイヤーで最後に確認したミッシングデバフを使って再判定します。死亡や塔踏みミス後もナビを継続しやすくします。"
-    };
-
     private static readonly InternationalString CircleMarkerKindText = new()
     {
         En = "Circle marker type",
@@ -295,7 +281,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private readonly List<uint> _firstSetIds = [];
     private readonly List<uint> _secondSetIds = [];
     private readonly Dictionary<uint, LiveDebuffKind> _initialHeadPartnerDebuffs = [];
-    private readonly Dictionary<uint, LiveDebuffKind> _lastKnownDebuffs = [];
     private PatternInfo _lastPattern = new();
     private string _lastRuleLabel = "";
     private string _lastSelectorLabel = "";
@@ -331,7 +316,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
     private string _lastInstructionLog = "";
 
     public override HashSet<uint>? ValidTerritories { get; } = [TerritoryDancingMadUltimate];
-    public override Metadata Metadata => new(10, "Garume");
+    public override Metadata Metadata => new(9, "Garume");
 
     private new IPlayerCharacter BasePlayer => global::Splatoon.Splatoon.BasePlayer;
 
@@ -491,8 +476,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
         _active = true;
         var debuff = DebuffFromStatus(status.StatusId);
-        if (debuff != LiveDebuffKind.None)
-            _lastKnownDebuffs[sourceId] = debuff;
         DebugLogOnce(ref _lastCaptureBlockLog, $"status-{sourceId:X8}-{status.StatusId}", $"STATUS_GAIN missing source=0x{sourceId:X8} status={status.StatusId} debuff={debuff}");
         TryCaptureResolvingSets();
         if (debuff != LiveDebuffKind.None && _allowLiveContextRefresh)
@@ -900,10 +883,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         DrawMarkerCommandInput(FanMarkerCommandText.Get(), ref C.FanMarkerCommand);
 
         ImGui.Spacing();
-        ImGui.Checkbox(UseLastKnownDebuffsText.Get(), ref C.UseLastKnownDebuffs);
-        ImGui.TextWrapped(UseLastKnownDebuffsDescriptionText.Get());
-
-        ImGui.Spacing();
         ImGui.Checkbox(UseWave8MarkerResolutionText.Get(), ref C.UseWave8MarkerResolution);
         ImGui.TextWrapped(UseWave8MarkerResolutionDescriptionText.Get());
         if (C.UseWave8MarkerResolution)
@@ -1149,7 +1128,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         ImGui.TextUnformatted($"First set: {FormatResolvingSet(_firstSetIds)}");
         ImGui.TextUnformatted($"Second set: {FormatResolvingSet(_secondSetIds)}");
         ImGui.TextUnformatted($"Initial head partners: {FormatInitialHeadPartnerDebuffs()}");
-        ImGui.TextUnformatted($"Last known debuffs: {FormatLastKnownDebuffs()}");
         ImGui.TextUnformatted($"Pending spawns: {FormatMapPositionList(_pendingTowerSpawnPositions)}");
         ImGui.TextUnformatted($"Pending clears: {FormatMapPositionList(_pendingTowerClearPositions)}");
         ImGui.TextUnformatted($"Last pattern: H{_lastPattern.Head}/C{_lastPattern.Circle}/F{_lastPattern.Fan}");
@@ -1646,7 +1624,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             return false;
         }
 
-        RememberVisibleDebuffs(party);
         var resolvingGroup = GetGroupPlayers(wave.ResolvingGroup, party);
         if (resolvingGroup.Count == 0)
         {
@@ -1657,7 +1634,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
         var supportGroup = GetSupportGroup(wave.ResolvingGroup, party, resolvingGroup);
         var useWave8MarkerContext = HasCompleteWave8MarkerCoverage(resolvingGroup);
-        var pattern = BuildLivePattern(resolvingGroup, useWave8MarkerContext, out var useLastKnownDebuffContext);
+        var pattern = BuildLivePattern(resolvingGroup, useWave8MarkerContext);
         if (!HasConfiguredPattern(pattern))
         {
             failureReason = $"no configured pattern {FormatPattern(pattern)} wave={_currentWave} stage={_currentStage}";
@@ -1667,40 +1644,25 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         _stageContexts.Clear();
         foreach (var player in party)
         {
-            var context = BuildLiveContext(player, resolvingGroup, supportGroup, pattern, useWave8MarkerContext, useLastKnownDebuffContext);
+            var context = BuildLiveContext(player, resolvingGroup, supportGroup, pattern, useWave8MarkerContext);
             _stageContexts[player.EntityId] = context;
         }
 
         if (!_stageContexts.ContainsKey(currentPlayer.EntityId))
-            _stageContexts[currentPlayer.EntityId] = BuildLiveContext(currentPlayer, resolvingGroup, supportGroup, pattern, useWave8MarkerContext, useLastKnownDebuffContext);
+            _stageContexts[currentPlayer.EntityId] = BuildLiveContext(currentPlayer, resolvingGroup, supportGroup, pattern, useWave8MarkerContext);
 
         return _stageContexts.Count > 0;
     }
 
-    private PatternInfo BuildLivePattern(
-        IReadOnlyList<IPlayerCharacter> resolvingGroup,
-        bool useWave8MarkerContext,
-        out bool useLastKnownDebuffContext)
+    private PatternInfo BuildLivePattern(IReadOnlyList<IPlayerCharacter> resolvingGroup, bool useWave8MarkerContext)
     {
-        useLastKnownDebuffContext = false;
         var statusPattern = PatternInfo.FromPlayers(resolvingGroup);
-        if (useWave8MarkerContext)
-        {
-            var markerPattern = PatternInfo.FromPlayers(resolvingGroup, Wave8MarkerEffectiveDebuff);
-            if (HasConfiguredPattern(markerPattern))
-                return markerPattern;
-        }
-
-        if (HasConfiguredPattern(statusPattern) || !C.UseLastKnownDebuffs)
+        if (!useWave8MarkerContext)
             return statusPattern;
 
-        var fallbackPattern = PatternInfo.FromPlayers(resolvingGroup, LastKnownDebuffFromPlayer);
-        if (HasConfiguredPattern(fallbackPattern))
-        {
-            useLastKnownDebuffContext = true;
-            DebugLog($"LAST_KNOWN_DEBUFF_PATTERN wave={_currentWave} stage={_currentStage} current={FormatPattern(statusPattern)} fallback={FormatPattern(fallbackPattern)}");
-            return fallbackPattern;
-        }
+        var markerPattern = PatternInfo.FromPlayers(resolvingGroup, Wave8MarkerEffectiveDebuff);
+        if (HasConfiguredPattern(markerPattern))
+            return markerPattern;
 
         return statusPattern;
     }
@@ -1710,8 +1672,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         IReadOnlyList<IPlayerCharacter> resolvingGroup,
         IReadOnlyList<IPlayerCharacter> supportGroup,
         PatternInfo pattern,
-        bool useWave8MarkerContext,
-        bool useLastKnownDebuffContext)
+        bool useWave8MarkerContext)
     {
         var side = resolvingGroup.Any(p => p.EntityId == me.EntityId)
             ? ParticipantSide.ResolvingGroup
@@ -1720,9 +1681,9 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                 : ParticipantSide.Any;
 
         var sideGroup = side == ParticipantSide.SupportGroup ? supportGroup : resolvingGroup;
-        var debuff = DebuffForLiveContext(me, side, useWave8MarkerContext, useLastKnownDebuffContext);
+        var debuff = DebuffForLiveContext(me, side, useWave8MarkerContext);
         var sameDebuffPlayers = sideGroup
-            .Where(player => DebuffForLiveContext(player, side, useWave8MarkerContext, useLastKnownDebuffContext) == debuff)
+            .Where(player => DebuffForLiveContext(player, side, useWave8MarkerContext) == debuff)
             .ToList();
         var debuffIndex = sameDebuffPlayers.FindIndex(player => player.EntityId == me.EntityId);
         var debuffRank = debuff == LiveDebuffKind.None || debuffIndex < 0 ? 0 : debuffIndex + 1;
@@ -1740,38 +1701,12 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             pattern);
     }
 
-    private LiveDebuffKind DebuffForLiveContext(
-        IPlayerCharacter player,
-        ParticipantSide side,
-        bool useWave8MarkerContext,
-        bool useLastKnownDebuffContext)
+    private LiveDebuffKind DebuffForLiveContext(IPlayerCharacter player, ParticipantSide side, bool useWave8MarkerContext)
     {
         if (side == ParticipantSide.ResolvingGroup && useWave8MarkerContext)
             return Wave8MarkerEffectiveDebuff(player);
 
-        if (useLastKnownDebuffContext)
-            return LastKnownDebuffFromPlayer(player);
-
         return CurrentDebuffFromPlayer(player);
-    }
-
-    private void RememberVisibleDebuffs(IEnumerable<IPlayerCharacter> players)
-    {
-        foreach (var player in players)
-        {
-            var debuff = CurrentDebuffFromPlayer(player);
-            if (debuff != LiveDebuffKind.None)
-                _lastKnownDebuffs[player.EntityId] = debuff;
-        }
-    }
-
-    private LiveDebuffKind LastKnownDebuffFromPlayer(IPlayerCharacter player)
-    {
-        var current = CurrentDebuffFromPlayer(player);
-        if (current != LiveDebuffKind.None)
-            return current;
-
-        return _lastKnownDebuffs.GetValueOrDefault(player.EntityId, LiveDebuffKind.None);
     }
 
     private LiveDebuffKind Wave8MarkerEffectiveDebuff(IPlayerCharacter player)
@@ -2658,9 +2593,7 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
     private string DebugPlayer(IPlayerCharacter player)
     {
-        var current = CurrentDebuffFromPlayer(player);
-        var known = _lastKnownDebuffs.GetValueOrDefault(player.EntityId, LiveDebuffKind.None);
-        return $"{player.Name}(0x{player.EntityId:X8},{current},known={known})";
+        return $"{player.Name}(0x{player.EntityId:X8},{CurrentDebuffFromPlayer(player)})";
     }
 
     private static string DebugIdentity(IPlayerCharacter player)
@@ -2679,17 +2612,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
             .OfType<IPlayerCharacter>()
             .ToDictionary(player => player.EntityId, player => player.Name.ToString());
         return string.Join(", ", _initialHeadPartnerDebuffs.Select(item =>
-            $"{players.GetValueOrDefault(item.Key, $"0x{item.Key:X8}")}:{item.Value}"));
-    }
-
-    private string FormatLastKnownDebuffs()
-    {
-        if (_lastKnownDebuffs.Count == 0) return "none";
-
-        var players = Controller.GetPartyMembers()
-            .OfType<IPlayerCharacter>()
-            .ToDictionary(player => player.EntityId, player => player.Name.ToString());
-        return string.Join(", ", _lastKnownDebuffs.Select(item =>
             $"{players.GetValueOrDefault(item.Key, $"0x{item.Key:X8}")}:{item.Value}"));
     }
 
@@ -2787,7 +2709,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
         _firstSetIds.Clear();
         _secondSetIds.Clear();
         _initialHeadPartnerDebuffs.Clear();
-        _lastKnownDebuffs.Clear();
         _lastPattern = new PatternInfo();
         _lastRuleLabel = "";
         _lastDebuff = LiveDebuffKind.Any;
@@ -3339,7 +3260,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
 
         public bool EnableLiveMarkerCommands;
         public bool UseWave8MarkerResolution;
-        public bool UseLastKnownDebuffs = true;
         public string CircleMarkerCommand = "/mk stop <me>";
         public string FanMarkerCommand = "/mk bind <me>";
         public P2_Forsaken_beta.MarkerResolveKind CircleMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Stop;
@@ -3681,12 +3601,6 @@ public class P2_Forsaken_beta : SplatoonScript<P2_Forsaken_beta.Config>
                 CircleMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Stop;
                 FanMarkerKind = P2_Forsaken_beta.MarkerResolveKind.Bind;
                 DefaultsVersion = 14;
-            }
-
-            if (DefaultsVersion < 15)
-            {
-                UseLastKnownDebuffs = true;
-                DefaultsVersion = 15;
             }
 
             for (var i = 0; i < Waves.Length; i++)


### PR DESCRIPTION
## Summary

- add opt-in self-marker command settings for Forsaken wave 4
- add separate free-form commands for circle and fan markers
- add optional wave 8 marker-based resolution with structured marker type selectors
- bump `P2_Forsaken_beta` metadata version to 9

## Notes

Marker commands are not sent by default. Duty recorder playback always logs the intended command locally instead of executing it.

## Validation

- `dotnet build SplatoonScripts/SplatoonScriptsOfficial.csproj --no-restore -v:minimal` (0 errors; existing SharpDX reference warnings remain)
