### PR TITLE
Update P3_Earthquake.cs

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P3_Earthquake.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P3_Earthquake.cs
@@ -202,7 +202,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
     private string _instruction = "";
 
     public override HashSet<uint>? ValidTerritories { get; } = [TerritoryDancingMadUltimate];
-    public override Metadata Metadata => new(33, "Garume");
+    public override Metadata Metadata => new(34, "Garume");
 
     public override void OnSetup()
     {
@@ -635,6 +635,31 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             C.AssignmentMode = (AssignmentMode)Math.Clamp(mode, 0, AssignmentModeNames.Length - 1);
         ImGui.TextWrapped(AssignmentModeDescription.Get());
 
+        if (C.AssignmentMode is AssignmentMode.FixedRoleAccretion)
+		{
+            ImGui.TextUnformatted("DPS/Support/Accretion spot assignment");
+            ImGui.Indent();
+            var dps = (int)C.DpsMarker;
+            if (DrawCombo("DPS", ref dps, ["A", "B", "C", "D"], 180f))
+                C.DpsMarker = (MapMarker)dps;
+            var support = (int)C.SupportMarker;
+            if (DrawCombo("Support", ref support, ["A", "B", "C", "D"], 180f))
+                C.SupportMarker = (MapMarker)support;
+            var accretion = (int)C.AccretionMarker;
+            if (DrawCombo("Accretion", ref accretion, ["A", "B", "C", "D"], 180f))
+                C.AccretionMarker = (MapMarker)accretion;
+            var fallback = (int)C.FallbackMarker;
+            if (DrawCombo("Fallback", ref fallback, ["A", "B", "C", "D"], 180f))
+                C.FallbackMarker = (MapMarker)fallback;
+
+            if (C.DpsMarker == C.SupportMarker || C.DpsMarker == C.AccretionMarker || C.DpsMarker == C.FallbackMarker ||
+                C.SupportMarker == C.AccretionMarker || C.SupportMarker == C.FallbackMarker ||
+                C.AccretionMarker == C.FallbackMarker)
+                ImGui.TextWrapped("Warning: DPS, Support, Accretion, and Fallback markers should be unique.");
+
+            ImGui.Unindent();
+		}
+
         if (C.AssignmentMode is AssignmentMode.Priority or AssignmentMode.MarkerThenPriority)
         {
             if (ImGui.Button("Apply Meow static TN priority"))
@@ -889,7 +914,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         var isAccretion = _accretionPlayers.Contains(player.EntityId);
         var isSupport = player.GetRole() is CombatRole.Tank or CombatRole.Healer;
         var rank = fixedSpots
-            ? isAccretion ? 2 : isSupport ? 0 : 1
+            ? isAccretion ? (int)C.AccretionMarker : isSupport ? (int)C.SupportMarker : (int)C.DpsMarker
             : isAccretion ? 2 : isSupport ? 1 : 0;
         slot = SlotFromRank(group, rank);
         return slot != Slot.None;
@@ -1822,7 +1847,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         var preferred = buckets[rank];
         if (_tetherTargets.ContainsKey(preferred))
             return preferred;
-        var fallback = buckets[3];
+        var fallback = buckets[(int)C.FallbackMarker];
         return _tetherTargets.ContainsKey(fallback) ? fallback : -1;
     }
 
@@ -2349,6 +2374,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
     public enum LineBaitDirection { Clockwise, Counterclockwise }
     public enum BlackHoleSourceOrder { ClockwiseFromNorth = 0, CounterclockwiseFromNorth = 1 }
     public enum BlackHoleOrderAnchor { KefkaPosition = 0, ArenaNorth = 1 }
+    public enum MapMarker { A = 0, B = 1, C = 2, D = 3 }
 
     private readonly record struct LiveTetherEntry(ushort Id, byte Progress, uint Target);
 
@@ -2400,6 +2426,10 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         public bool ShowFinalTowerText = true;
         public InternationalString FinalMoveText = new() { En = "{0}: spread and keep moving", Jp = "{0}: 散開して動く" };
         public bool ShowFinalMoveText = true;
+        public MapMarker DpsMarker = MapMarker.B;
+        public MapMarker SupportMarker = MapMarker.A;
+        public MapMarker AccretionMarker = MapMarker.C;
+        public MapMarker FallbackMarker = MapMarker.D;
 
         public void EnsureDefaults()
         {


### PR DESCRIPTION
add settings to let user switch markers when using fixed role/accretion spots setting

as a side note, I don't think the script works as intended as I assume it tries to emulate this raidplan https://raidplan.io/plan/HUCRZOBZ9MGvqpiR
however in case I am wrong I didn't change how it works just that you can decide what role goes to which marker

PS: let the defaults as the same they were originally so people that already had it don't need to change anything