### PR TITLE
Fix tower countdown drawing timing

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken.cs
@@ -20,7 +20,7 @@ namespace SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad;
 
 public unsafe class P2_Forsaken : SplatoonScript<P2_Forsaken.Config>
 {
-    public override Metadata Metadata { get; } = new(9, "NightmareXIV, Poneglyph, mirage");
+    public override Metadata Metadata { get; } = new(10, "NightmareXIV, Poneglyph, mirage");
     public override HashSet<uint>? ValidTerritories { get; } = [1363];
 
     public uint EffectSpread = 5085;
@@ -208,10 +208,13 @@ public unsafe class P2_Forsaken : SplatoonScript<P2_Forsaken.Config>
     public override void OnUpdate()
     {
         Controller.Hide();
-        if(C.ShowTowerCountdown)
-            UpdateTowerLifetimeElements();
         if(Controller.GetPartyMembers().Any(x => x.StatusList.Any(s => s.StatusId == DebuffSpellsTrouble)))
         {
+            if(C.ShowTowerCountdown)
+            {
+                UpdateTowerLifetimeElements();
+            }
+
             var pcs = Svc.Objects.OfType<IPlayerCharacter>().ToList();
             int i = 0;
             foreach(var x in ActiveMapEffects)


### PR DESCRIPTION

> @Limiana I wanted to report an issue with the p2 visualizer - if you have 'show tower countdown' turned on, those timers persist on the arena even throughout p3, doesn't get removed until you wipe. (i'm on the v9 script)
<img width="731" height="229" alt="image" src="https://github.com/user-attachments/assets/01fd8a10-d437-4283-ace2-defb5db9cded" />

https://ptb.discord.com/channels/1001823907193552978/1107282120541491252/1515944966550061097