### PR TITLE
Fix P3 Earthquake final anchor handling

### DIFF
--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P3_Earthquake.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P3_Earthquake.cs
@@ -223,8 +223,6 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
     private uint _kefkaId;
     private Vector3? _kefkaPosition;
     private readonly List<Vector3> _finalTowerPositions = [];
-    private Vector3? _finalFootAnchorPosition;
-    private string _finalFootAnchorDebug = "";
     private uint _selfTetherTarget => _selfBlackHoleTask?.Target ?? 0;
     private int _currentWindow = -1;
     private int _fixedLaneSetStartWindow = -1;
@@ -243,7 +241,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
     private string _instruction = "";
 
     public override HashSet<uint>? ValidTerritories { get; } = [TerritoryDancingMadUltimate];
-    public override Metadata Metadata => new(39, "Garume");
+    public override Metadata Metadata => new(40, "Garume");
 
     public override void OnSetup()
     {
@@ -305,7 +303,6 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         RefreshBasePlayerState();
         var packetRotation = packet == null ? (float?)null : packet->Rotation;
         UpdateKefkaAnchor(source, castId, packetRotation);
-        ObserveFinalAnchor(source, castId, packetRotation);
         ObserveFinalTowerSource(source.GetObject(), null, castId, origin);
 
         if (castId is UltimateEmbrace or BowelsOfAgony)
@@ -733,7 +730,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         ImGui.TextWrapped($"KefkaCandidates={KefkaCandidateText()}");
         ImGui.TextUnformatted($"Final={_finalStage} Landing={_landingCount} Markers={_finalStackMarkerCount} FirstStack={_firstFinalStackRole} SecondStack={_secondFinalStackRole} CurrentStack={_currentFinalStackRole}");
         ImGui.TextUnformatted($"FinalDondokoHits={_finalDondokoHitCount}");
-        ImGui.TextUnformatted($"FinalAnchor={FinalAnchorDebugText()} FinalPairAnchor={FinalPairAnchorDebugText()} Towers={FinalTowerDebugText()}");
+        ImGui.TextUnformatted($"FinalPairAnchor={FinalPairAnchorDebugText()} Towers={FinalTowerDebugText()}");
         if (!string.IsNullOrWhiteSpace(_guideDebug))
             ImGui.TextUnformatted(_guideDebug);
         ImGui.Unindent();
@@ -1201,7 +1198,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             ? FinalStackRole.Support
             : FinalStackRole.Dps;
         var goNorth = ownStackRole == northRole;
-        var angle = NormalizeAngle(FinalFootAnchorAngle() + (goNorth ? 0.0f : MathF.PI));
+        var angle = NormalizeAngle(OrderAnchorAngle() + (goNorth ? 0.0f : MathF.PI));
         destination = PositionFromDirectionAngle(angle, FinalInitialSplitRadius);
         text = TextOrEmpty(C.ShowFinalRoleSplitText, C.FinalRoleSplitText, ownStackRole == FinalStackRole.Support ? "Support" : "DPS");
         return true;
@@ -1340,8 +1337,6 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         _finalStackMarkerCount = 0;
         _finalDondokoHitCount = 0;
         _finalTowerPositions.Clear();
-        _finalFootAnchorPosition = null;
-        _finalFootAnchorDebug = "";
     }
 
     private void ClearBlackHoleState()
@@ -1551,52 +1546,6 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             CaptureKefka(obj, force);
     }
 
-    private void ObserveFinalAnchor(uint source, uint actionId, float? packetRotation)
-    {
-        if (actionId == DondokoCast)
-        {
-            if (TryCaptureFinalDondokoAnchor(source, packetRotation))
-                return;
-            if (source.GetObject() is { } obj && IsKefkaAnchorObject(obj))
-                FreezeFinalFootAnchor(FlatPosition(obj.Position), $"source-{Describe(source)}", force: true);
-            else if (TryCaptureFinalAnchorFromRotation(source, packetRotation))
-                return;
-        }
-
-        if (_finalFootAnchorPosition.HasValue || actionId is not (LateP3Blizzaga or DondokoCast or LandingCast))
-            return;
-        if (TryGetKefkaPosition(out var position))
-            FreezeFinalFootAnchor(position, string.IsNullOrWhiteSpace(_kefkaAnchorDebug) ? $"cached-{actionId}" : _kefkaAnchorDebug);
-    }
-
-    private bool TryCaptureFinalDondokoAnchor(uint source, float? packetRotation)
-    {
-        float rotation;
-        if (source.GetObject() is { } obj)
-        {
-            if (obj.DataId != FinalDondokoDataId)
-                return false;
-            rotation = obj.Rotation;
-        }
-        else if (!TryGetKefkaAnchorRotation(source, packetRotation, out rotation))
-            return false;
-
-        var angle = NormalizeAngle(rotation + MathF.PI);
-        FreezeFinalFootAnchor(PositionFromDirectionAngle(angle, KefkaVirtualAnchorRadius),
-            $"dondoko-19504-rotation {Deg(rotation):F1}+180", force: true);
-        return true;
-    }
-
-    private bool TryCaptureFinalAnchorFromRotation(uint source, float? packetRotation)
-    {
-        if (!TryGetKefkaAnchorRotation(source, packetRotation, out var rotation))
-            return false;
-
-        var angle = NormalizeAngle(rotation - MathF.PI / 2.0f);
-        FreezeFinalFootAnchor(PositionFromDirectionAngle(angle, KefkaVirtualAnchorRadius), $"rotation-fallback {Deg(rotation):F1}-90");
-        return true;
-    }
-
     private void ObserveFinalTowerSource(IGameObject? source, Vector3? eventPosition, uint actionId, string origin)
     {
         if (actionId is not (DondokoHit or TowerImpact))
@@ -1667,11 +1616,8 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         return !float.IsNaN(offset);
     }
 
-    private float OrderAnchorAngle() => C.BlackHoleOrderAnchor switch
-    {
-        BlackHoleOrderAnchor.KefkaPosition when TryGetKefkaPosition(out var kefka) => DirectionAngle(kefka),
-        _ => 0.0f
-    };
+    private float OrderAnchorAngle() =>
+        TryGetKefkaPosition(out var kefka) ? DirectionAngle(kefka) : 0.0f;
 
     private float SourceAngle(int bucket) =>
         _tetherSources.TryGetValue(bucket, out var source) ? DirectionAngle(source) : BucketAngle(bucket);
@@ -1681,12 +1627,9 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             ? NormalizeAngle(sourceAngle - anchorAngle)
             : NormalizeAngle(anchorAngle - sourceAngle);
 
-    private string OrderAnchorDebugText() => C.BlackHoleOrderAnchor switch
-    {
-        BlackHoleOrderAnchor.KefkaPosition when TryGetKefkaPosition(out var pos) =>
-            $"{(string.IsNullOrWhiteSpace(_kefkaAnchorDebug) ? "Kefka" : _kefkaAnchorDebug)}({pos.X:F1},{pos.Z:F1})",
-        _ => "N"
-    };
+    private string OrderAnchorDebugText() => TryGetKefkaPosition(out var pos)
+        ? $"{(string.IsNullOrWhiteSpace(_kefkaAnchorDebug) ? "Kefka" : _kefkaAnchorDebug)}({pos.X:F1},{pos.Z:F1})"
+        : "N";
 
     private static Vector3 FlatPosition(Vector3 position) => new(position.X, 0.0f, position.Z);
 
@@ -2241,34 +2184,7 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             : _finalTowerPositions.OrderBy(position => AngleDistance(DirectionAngle(position), angle)).First();
     }
 
-    private float FinalFootAnchorAngle()
-    {
-        if (!_finalFootAnchorPosition.HasValue)
-        {
-            if (TryGetKefkaPosition(out var position))
-                FreezeFinalFootAnchor(position, string.IsNullOrWhiteSpace(_kefkaAnchorDebug) ? "lazy-cached" : _kefkaAnchorDebug);
-        }
-
-        return _finalFootAnchorPosition is { } anchor ? DirectionAngle(anchor) : 0.0f;
-    }
-
     private float FinalPairAnchorAngle() => OrderAnchorAngle();
-
-    private void FreezeFinalFootAnchor(Vector3 position, string reason, bool force = false)
-    {
-        if (_finalFootAnchorPosition is { } old)
-        {
-            if (!force || Vector3.DistanceSquared(old, position) <= 0.25f)
-                return;
-        }
-
-        _finalFootAnchorPosition = position;
-        _finalFootAnchorDebug = reason;
-    }
-
-    private string FinalAnchorDebugText() => _finalFootAnchorPosition is { } anchor
-        ? $"{_finalFootAnchorDebug}({anchor.X:F1},{anchor.Z:F1})"
-        : "N fallback";
 
     private string FinalPairAnchorDebugText() => $"blackhole-order {OrderAnchorDebugText()}";
 

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P3_Earthquake.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P3_Earthquake.cs
@@ -109,6 +109,8 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         ["Party marker", "Priority", "PF role/accretion", "Fixed role/accretion spots", "Fixed marker lanes"];
     private static readonly string[] MapMarkerNames = ["A", "B", "C", "D"];
     private static readonly string[] LineBaitDirectionNames = ["Clockwise", "Counterclockwise"];
+    private static readonly string[] FirstWindowBaitDirectionNames = ["Same as line bait direction", "Clockwise", "Counterclockwise"];
+    private static readonly string[] FirstPairAssignmentNames = ["Source order", "First slot nearest"];
     private static readonly string[] FirstOrbRoleNames = ["DPS", "Support"];
     private static readonly RolePosition[] DefaultRolePriority =
     [
@@ -145,8 +147,18 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
     };
     private static readonly InternationalString LineBaitDirectionDescription = new()
     {
-        En = "Line bait direction controls where your bait marker is placed from the Black Hole that is currently tethered to you. Clockwise and Counterclockwise are relative to the arena center. In Fixed marker lanes, DPS/Support directions choose the source search order; this setting still controls the final bait offset.",
-        Jp = "Line bait direction は、自分に付いたブラックホールを基準に誘導先を時計回り/反時計回りのどちらへずらすかを決めます。方向はフィールド中央基準です。Fixed marker lanes では DPS/Support direction は線の探索順にだけ使い、最終的な線を引っ張る位置はこの設定で決まります。"
+        En = "Line bait direction controls where your bait marker is placed from the Black Hole that is currently tethered to you. Clockwise and Counterclockwise are relative to the arena center. In Fixed marker lanes, DPS/Support directions choose the source search order; this setting still controls the final bait offset except when the first-window override is used.",
+        Jp = "Line bait direction は、自分に付いたブラックホールを基準に誘導先を時計回り/反時計回りのどちらへずらすかを決めます。方向はフィールド中央基準です。Fixed marker lanes では DPS/Support direction は線の探索順にだけ使います。First window bait direction で別の方向を選んでいる場合を除き、実際に線を引っ張る位置はこの設定で決まります。"
+    };
+    private static readonly InternationalString FirstWindowBaitDirectionDescription = new()
+    {
+        En = "First window bait direction overrides only the bait position for the first Black Hole window. It does not change which Black Hole is selected.",
+        Jp = "最初のブラックホール window だけ、線を引っ張る誘導先方向を上書きします。取るブラックホール自体は変えません。"
+    };
+    private static readonly InternationalString FirstPairAssignmentDescription = new()
+    {
+        En = "First pair assignment controls how the first two-line Black Hole window selects sources. Source order uses the configured Black Hole source order. First slot nearest makes the first slot take the visible Black Hole closest to that player, and the second slot takes the other visible Black Hole.",
+        Jp = "First pair assignment は、最初に2本出るブラックホール window の線選択を決めます。Source order は設定した Black Hole source order を使います。First slot nearest は、1番目のスロットがそのプレイヤーに最も近いブラックホールを取り、2番目のスロットがもう片方を取ります。"
     };
     private static readonly InternationalString BlackHoleSourceOrderDescription = new()
     {
@@ -631,6 +643,14 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         if (DrawCombo("Line bait direction", ref direction, LineBaitDirectionNames, 180f))
             C.LineBaitDirection = (LineBaitDirection)Math.Clamp(direction, 0, 1);
         ImGui.TextWrapped(LineBaitDirectionDescription.Get());
+        var firstWindowDirection = (int)C.FirstWindowBaitDirection;
+        if (DrawCombo("First window bait direction", ref firstWindowDirection, FirstWindowBaitDirectionNames, 260f))
+            C.FirstWindowBaitDirection = (FirstWindowBaitDirection)Math.Clamp(firstWindowDirection, 0, FirstWindowBaitDirectionNames.Length - 1);
+        ImGui.TextWrapped(FirstWindowBaitDirectionDescription.Get());
+        var firstPairAssignment = (int)C.FirstPairAssignment;
+        if (DrawCombo("First pair assignment", ref firstPairAssignment, FirstPairAssignmentNames, 220f))
+            C.FirstPairAssignment = (FirstPairAssignment)Math.Clamp(firstPairAssignment, 0, FirstPairAssignmentNames.Length - 1);
+        ImGui.TextWrapped(FirstPairAssignmentDescription.Get());
 
         var sourceOrder = (int)C.BlackHoleSourceOrder;
         if (DrawCombo("Black Hole source order", ref sourceOrder, ["Clockwise", "Counterclockwise"], 180f))
@@ -1704,7 +1724,12 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
 
     private Vector3 BlackHoleStandPosition(Vector3 source)
     {
-        var side = C.LineBaitDirection == LineBaitDirection.Counterclockwise ? -1.0f : 1.0f;
+        var direction = _currentWindow == 0 && C.FirstWindowBaitDirection != FirstWindowBaitDirection.SameAsLineBaitDirection
+            ? C.FirstWindowBaitDirection == FirstWindowBaitDirection.Counterclockwise
+                ? LineBaitDirection.Counterclockwise
+                : LineBaitDirection.Clockwise
+            : C.LineBaitDirection;
+        var side = direction == LineBaitDirection.Counterclockwise ? -1.0f : 1.0f;
         var radius = _currentWindow == 9 ? LastBlackHoleGuideRadius : BlackHoleGuideRadius;
         var angle = DirectionAngle(source) + side * MathF.PI / 4.0f;
         var best = PositionFromDirectionAngle(angle, radius);
@@ -1767,6 +1792,9 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
 
     private int ExpectedBucket(Slot slot)
     {
+        if (TryFirstPairBucket(slot, out var firstPairBucket))
+            return firstPairBucket;
+
         var rank = ExpectedRank(slot, _currentWindow);
         if (C.AssignmentMode == AssignmentMode.FixedRoleAccretion)
             return ExpectedFixedSpotBucket(rank);
@@ -1774,6 +1802,46 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             return ExpectedFixedMarkerLaneBucket(slot, rank);
         var buckets = OrderedActiveBuckets();
         return rank >= 0 && rank < buckets.Count ? buckets[rank] : -1;
+    }
+
+    private bool TryFirstPairBucket(Slot slot, out int bucket)
+    {
+        bucket = -1;
+        if (C.FirstPairAssignment != FirstPairAssignment.FirstSlotNearest || _currentWindow != 1 ||
+            slot is not (Slot.Attack1 or Slot.Attack2))
+            return false;
+
+        var activeBuckets = _tetherTargets.Keys.Where(_tetherSources.ContainsKey).ToList();
+        if (activeBuckets.Count != 2)
+            return false;
+
+        IPlayerCharacter? firstPlayer = null;
+        foreach (var player in Svc.Objects.OfType<IPlayerCharacter>())
+        {
+            if (!_groups.ContainsKey(player.EntityId)) continue;
+            if (TryResolveSlot(player, out var resolved, out _) && resolved == Slot.Attack1)
+            {
+                firstPlayer = player;
+                break;
+            }
+        }
+
+        if (firstPlayer == null)
+            return false;
+
+        var firstPosition = FlatPosition(firstPlayer.Position);
+        var firstBucket = activeBuckets
+            .OrderBy(activeBucket =>
+            {
+                var source = _tetherSources[activeBucket];
+                return Vector2.DistanceSquared(
+                    new Vector2(firstPosition.X, firstPosition.Z),
+                    new Vector2(source.X, source.Z));
+            })
+            .ThenBy(activeBucket => activeBucket)
+            .First();
+        bucket = slot == Slot.Attack1 ? firstBucket : activeBuckets.First(activeBucket => activeBucket != firstBucket);
+        return true;
     }
 
     private int ExpectedFixedSpotBucket(int rank)
@@ -1945,6 +2013,8 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             return "slot=none";
         if (rank < 0)
             return "not-assigned-this-window";
+        if (TryFirstPairBucket(slot, out var firstPairBucket))
+            return $"first-pair nearest expected={DirectionName(firstPairBucket)}";
         if (C.AssignmentMode == AssignmentMode.FixedMarkerLanes)
             return FixedMarkerLaneDecisionText(slot, rank);
         if (C.AssignmentMode == AssignmentMode.FixedRoleAccretion)
@@ -2469,6 +2539,8 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
     private enum TargetGroup { None, Attack, Bind, Stop }
     private enum Slot { None, Attack1, Attack2, Attack3, Bind1, Bind2, Bind3, Stop1, Stop2 }
     public enum LineBaitDirection { Clockwise, Counterclockwise }
+    public enum FirstWindowBaitDirection { SameAsLineBaitDirection = 0, Clockwise = 1, Counterclockwise = 2 }
+    public enum FirstPairAssignment { SourceOrder = 0, FirstSlotNearest = 1 }
     public enum BlackHoleSourceOrder { ClockwiseFromNorth = 0, CounterclockwiseFromNorth = 1 }
     public enum BlackHoleOrderAnchor { KefkaPosition = 0, ArenaNorth = 1 }
     public enum FirstOrbRole { Dps = 0, Support = 1 }
@@ -2482,6 +2554,8 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
         public AssignmentMode AssignmentMode = AssignmentMode.PartyMarker;
         public FirstOrbRole FirstOrbRole = FirstOrbRole.Dps;
         public LineBaitDirection LineBaitDirection = LineBaitDirection.Clockwise;
+        public FirstWindowBaitDirection FirstWindowBaitDirection = FirstWindowBaitDirection.SameAsLineBaitDirection;
+        public FirstPairAssignment FirstPairAssignment = FirstPairAssignment.SourceOrder;
         public BlackHoleSourceOrder BlackHoleSourceOrder = BlackHoleSourceOrder.ClockwiseFromNorth;
         public BlackHoleOrderAnchor BlackHoleOrderAnchor = BlackHoleOrderAnchor.KefkaPosition;
         public FinalInitialBaitMode FinalInitialBaitMode = FinalInitialBaitMode.Center;
@@ -2545,6 +2619,8 @@ public unsafe class P3_Earthquake : SplatoonScript<P3_Earthquake.Config>
             AssignmentMode = NormalizeAssignmentMode(AssignmentMode);
             FirstOrbRole = (FirstOrbRole)Math.Clamp((int)FirstOrbRole, 0, FirstOrbRoleNames.Length - 1);
             LineBaitDirection = (LineBaitDirection)Math.Clamp((int)LineBaitDirection, 0, 1);
+            FirstWindowBaitDirection = (FirstWindowBaitDirection)Math.Clamp((int)FirstWindowBaitDirection, 0, FirstWindowBaitDirectionNames.Length - 1);
+            FirstPairAssignment = (FirstPairAssignment)Math.Clamp((int)FirstPairAssignment, 0, FirstPairAssignmentNames.Length - 1);
             DpsLineBaitDirection = ClampLineBaitDirection(DpsLineBaitDirection);
             SupportLineBaitDirection = ClampLineBaitDirection(SupportLineBaitDirection);
             AccretionLineBaitDirection = ClampLineBaitDirection(AccretionLineBaitDirection);


### PR DESCRIPTION
## Summary
- remove the separate final-foot anchor capture/state path
- route the final initial split, final spread, and final tower guides through the existing order anchor path
- use the cached Kefka anchor when available, falling back to true north only when no anchor is cached