### PR TITLE
fix JP Forsaken Script add ShowHint Options

### DIFF
--- a/Presets/Dawntrail/Raids/Ultimate - Dancing Mad/Phase 2/3. Forsaken individual scripts.md
+++ b/Presets/Dawntrail/Raids/Ultimate - Dancing Mad/Phase 2/3. Forsaken individual scripts.md
@@ -22,12 +22,12 @@ Reference
 https://raw.githubusercontent.com/PunishXIV/Splatoon/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_KT_Strat.cs
 ```
 
-Yarn Priority & Piren Configure (ヤーン速報 ①ミッシング 優先順+立ち位置ぴれん)
+### [JP] Yarn Priority & Piren Configure (ヤーン速報 ①ミッシング 優先順+立ち位置ぴれん)
 ```
-{"TargetScriptName":"SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P2_Missing_1238_4567_KT_Strat","ConfigurationName":"Yarn Priority 20260610","Configuration":"Gy0LAJwFzrmcQIgfvULQrkO5+/veICJbfX3fuZTdi2+7n4zdjkExpAf2ikXHsuXyjmYEQmJsax5lYe6OpbvWNBZhevWtxyOExTrkHwo7wMU6sKr7zK/DYjJQF7BBBapHgVbwfHS7pK66U/V6NhlaC1JEvHEKoCW2iWqhxTUTBNOZvvEf1KBhjSQjbRo+Q4UFfcMiaUyYIASavFZl8xivIj2BpVI8LlZAcynYlTT5f3mDUjtIAkyRBCAJhOQQkoDJXBq8JrVS7V+AHYdCChCGx8cxFthUvJ1ZfLSjeY0ykOCmSQrATA1qt2/fH9146PC3WeMfLBP7Hmmp79Gq11PAtfLz3+kP9xDHhlYl16WcbLbXRM+2GRlFAuxkMHlD1dv38DxR3CyQ9hqI+QGYZ+NOrf2+jaFQxTRSj09LvTxPtdOFgsS2P8OEIgoEIW/js24LfGG+oliO/flGbEu4mYDVGPIVI5vG7Fdk4U8CMaYdi5q2XL9zXexrpkbZfvq/aToynEk0S2bKzhYTG1qfa+TNGJv8uPhgiIboAQ==","Overrides":null}
+{"TargetScriptName":"SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P2_Missing_1238_4567_KT_Strat","ConfigurationName":"絶妖星乱舞_ヤーン速報_20260929","Configuration":"G90LACwKbBu5NRhapWFTeNhpofVQK+z+vrNyLqEqfGaFq60jC6gYLiX4V3VT9rn/0rYbYOEI8LgrikUnQHz+71fn2xQOJuCIFg0X6cx9NRHFY3W8ejuoQWB11Rb/W/o6YstOuDL4mFnfxGIaoC68G4jCGQ3GsILX959LhudPxImJE74WlIB83AbgYttEV3rUc2JzP93xazd10jmZ3OP6E1RYJDatNDMJIQTBWDS9nTTxWd1MYKkUnysCmkvBrmQi1uSfVmqnJwFtJAE9CezJYU8Cea4eiybYWni3BDsORTCAGBE1YwJgU3Y6s6S1o/keDlJA6XEqADN1Yq9bdV6GSQT0NGtALRaqVdKGs6Si15NTNW/DXHV/q164B5MNU1rGyyw2puRsRsycXbEQBZCTP8E+u7UYK7STBGVOCSChUJTgaOnJ4fr0jtyqoH0gApk5uy2MYu4KuOj4znH2PpKgWYXrshm/PakZK61qkK6YT7ClyMIJjy78p7o39EPAGzpU8bVm+d7gYqavRvhvmLGXH1Ie+JfoEV/soNQULNe/uS6utNKka/vRphTvl2v5MqIjVfiMW0D1Y83oiLnJ7yyhaopGr6zb5XE8ISg906cwFpcAAOpDlrJTh0LaCAEmiMjBHeQLGCPldV3gDw==","Overrides":null}
 ```
 
-## [JP] Yarn - new, updated positions (needs verification)
+### [JP] Yarn - new, updated positions (needs verification)
 ```
 {"TargetScriptName":"SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P2_Missing_1238_4567_KT_Strat","ConfigurationName":"","Configuration":"G/cKACwLeHNOKc2MZLGHr4FCrdqlwt577f42iMhWX2i2pW53t4ehpq66LVVZaIYotxgEiyHpOAf54RaLTjV0WbncxL22D6guUfo3lFKFqUIyuVCr7B5hBBbtElRMlhO5MtMI3lem4xtk1IX/BqIcoU0DfClLqhSoChALDcYYLS7B/+aJTt/nqOaMYCCQXWgRzgERxlHM6w/zLIZ1A1mMvKxUx2lAjTTAaWCnh50GcnYLIGLdxk9YE7C4AJiBSBnTWY9G358ss9Ycn6ENR0R1nAuWllbtWc64MdMh8r5pMEMsM386U4Wo7xLOtGKp1v60oI2WXRKjovQEjVSO0uiRRuxhCPkNWmJ5HnGhDLXwFG0L2GyKK7TJ6zVuUhptkTjh1+b62KkIp+j8D94Y5TqUq0+7JxgpuYMOPOmbrPYmKks4p25oeX8Jx318naLSOlbJjEUPsuiJqWbcIo9X5WEe2ErRD+KQFqj9oANPuM49vuVwgDupAw==","Overrides":"GyVsIKwKeHMepA4UJ6NAJRB8y86lDsh77f6WSB+obsoTT7qxc249x2yb9p+11/wKK8DIQzEOKaNqfPz+782zllglD8jSbyKLEfrz7ryU0rF0oLd/JqU2oO68jAHZcjwBy8lr/0N5lV8To/GGLoe2VGzDONTloJLjjxKjU8tIz749UmY1sX5ByykN5IOpdUz8bwrBwefITSpgq+0im8WPeNJMgrGVH/Gkpo1Et9Wwz+aZQKA1sE6T8dnU1+dUJSelBv8pE5zq68dy1pdi3/7d5q9lrNi5OfhHvdjXPcd6PeRpjEecWrTCErXbNlE9tCx6goJTkxGaI6a1ePKTyxC2hQ6kKXPj5/NcZtl6HPxuWC24ZyNUzBBk0QnVMo5XIuyoUG+4IYkp7hhpgOdwuh3tYuTCzf1yEU+gciAE7mVMCd1zrRElXiXYbaTPMTi0Z83xJ5tGPHrbOtsbvohtBU5/mWcZwxtyn89951rDt9cpfkAZryIArATPcL4qZ9r0HgpYCSDPJCZHYcI24z4NqIJnRdHNkAAymiDJRcgrEm5O4mc6Y9xk+MV9eCKM9YSDsm84grJYBcqJ5rhyj3DC8woD5gZKynCzNs8APcwlej7xmU6GeHEHYfHwHJLBOlXUMEaER8HMtpW99GN4Ep6efOXOEZCAFLSV5N6Vo0dFoqKntXLnyIgfJS7pI/ogZRivLbfzSjBUOZU9QQwyEaEaQ5AgFHmWLCvmVZfMNWjtlsoahyqzBZslIYmuCEXIYGU83HowuXljfaZ6g34I3QjW7En1Ct9aGUhRQT4rCq4vshI+lyq8zpf1lUsJYsYXVLFcIpVDlQQQ8URFPdJSqUN2FROk1OoBRKezoCtSQhCUoRdR9G5KjSMSLFPfgGDLo2qOhkStZFD8AstT7R/fxlbahKlrIGqBglTvXJeazRM6XcAZ6R/fnafCK7QgE4dMylkH6EbbJiI9FK2iw6n9SHLcfDpE+yI0Rlzk0QpOcqpKmFojt+jH1TTgWbtq2BVf2elIsRb+eL4imypXjuPJ3CYIeJH+LOE25HkGAK74t/r/iXhCZauuqW3fyae8UAX7WwX1A354/spOWWyHeZkCgBZZ9bC8TwFAibxPAYBEXqYA4Aq3F8TI6+kfNZ5+WwkABECAeleLbyPafD2wWKYp"}
 ```
@@ -53,67 +53,9 @@ Reference
 https://raw.githubusercontent.com/PunishXIV/Splatoon/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_KT_Alt.cs
 ```
 
-Yarn BackSwap & Piren Configure (ヤーン速報 ②ミッシング 南調整+立ち位置ぴれん)
+### [JP] Yarn BackSwap & Piren Configure (ヤーン速報 ②ミッシング 南調整+立ち位置ぴれん)
 ```
-{"TargetScriptName":"SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P2_Misisng_KT_Alt","ConfigurationName":"Yarn SouthSwap 20260609","Configuration":"GyILAJwHto1kHXSMH1tB6LJW2P191yAiXX3NmkvZTvzBJiUL6FhV4SOmDkuD//+npgODUsBFPUG676W3e4qW96DS1oJAWWv5Fu8yvHRq61LubrfFYoq6EDYQNSb06ABfAZJ1FqhBi9GFBmBqGjEkmCf6jLRIagEEwJiY1IwvwiV6IhRHBZKOg/KsAK4NY5Ev/6y8DmIA1sgAEAOEmCHEACbRMiLG0AZV7xhXgjARsmt0GQsZTSYqCXkmznCySjhpXGPzyKLb/rKl2/4Z4unpomoRaUt7S3HwZXciuIVojhKBP5nJ8Vw6+9Z2ENo7uzqIlsp3xJL/LOUZ4LmP839ctEQH5W1yR19bdlxXJMJHdRf7WDg1xy/x9kRzgHudz9cPhp8RChB65yAUFNJnMR6q3LmMuXQSQO3+cPefHt1xBbGtmpqp9oTlXi9OnPo2ud+2WLG6w3sLPxX3UX9So7isKOd0TEycWlJS5AgKky+g5PhaLhtV4wDl+y3uxgE=","Overrides":null}
-```
-
-## [JP] Old Yarn
-
-P2_Missing_1238_4567 (called Old Yarn)
-Resolve By Party Priority [0-3] / [4-7]
-
-- Stack + Priority High → FirstHalf
-- Remained 2 → SecondHalf
-
-```
-https://github.com/PunishXIV/Splatoon/raw/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1234_5678.cs
-```
-
-## [JP] Old Yarn
-
-Resolve By Party Priority [0, 2] / [1, 3] / [4, 6] / [5, 7]
-
-[0, 2] & [1.,3]
-
-- Contain Stack Pair → FirstHalf
-- Remained Pair→ SecondHalf
-
-[4, 6] & [5, 7]
-
-- Contain Stack Pair → FirstHalf
-- Remained Pair→ SecondHalf
-
-```
-https://github.com/PunishXIV/Splatoon/raw/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_Pair.cs
-```
-
-## [JP] Missing Poikos Strat
-
-Resolve By Party Priority [0-3] / [4-7]
-
-- Stack + Priority High → FirstHalf
-- Remained 2 → SecondHalf
-
-```
-https://github.com/PunishXIV/Splatoon/raw/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_Pair.cs
-```
-
-## [Maybe JP] Halfswap strat/Custom roles
-```
-https://github.com/PunishXIV/Splatoon/raw/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1234_5678_CustomRoles.cs
-```
-
-## Missing 1238/4567 KT Strat
-
-with pair-based half assignment and generic priority roles
-```
-https://github.com/PunishXIV/Splatoon/raw/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_KT_Strat.cs
-```
-
-## Drippy strat
-```
-https://github.com/PunishXIV/Splatoon/raw/refs/heads/main/SplatoonScripts/Duties/Dawntrail/Dancing%20Mad/P2_Forsaken_Pattern/P2_Missing_1458_2367_Drippy.cs
+{"TargetScriptName":"SplatoonScriptsOfficial.Duties.Dawntrail.Dancing_Mad@P2_Misisng_KT_Alt","ConfigurationName":"絶妖星乱舞_ヤーン速報_20260629","Configuration":"G3QMACwKbBuZNxh6uHhYCsKq1bXC7u+7BhHp6gvNnMrPj8sD6aZ8z7aFROjsQqNRXddfFPNi0bFsOZp8iUQZhGyKvFSzt790Vbpx6C+0akuXzWi0xkok5wgSG7Jl5w0xmvHR2E6LxYS6IBvUhEY0aQMfC8maDJVB4GYaQGucmKC/eaLVdYtIExAAT9CtFhaEumckhKP8Ke8gnuXHscETfuVN6tNxNGCONMDRII4ecTSwExtX4DHWLjkjHAlCYiC7WvFYSDUZSRLKntjHzkr/k8Z6k0XnLGJiPhOXZDWepBaRVLVcLB11M+EYkcPE0N77lu5qy3gyY4b/xNW3uEfqrQDO39qVPeDjbOf/Kkr4o7zOUr1MTng03mobJOOVlu1VsWt6D/HGyHIAH+fz9YXhY9ALQp05BAVB+qw1HFLuwmMumwTPaqSO7kVbpyjEGKU1U31OWPa4BJaldp23LmzcREw1hpP9fyp8qd+lZrN8WnOR7GmQRvYqxEf2Ss++C3o8dZCJQe0BYBgXkPAHUbIWoXR92gu1dIxAh6DewDD6Imhh6aBgq4AtuT+jrM5T+BUsRPQV4zJHXlJblZCYaYcEZkSKuPEijHa6SF3ONOkpVQpIXdszs9Ds5LrJsEZTLDVZEQKirYXuCxlqwRoGBw==","Overrides":null}
 ```
 
 ## [NA/EU] Rinon

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_KT_Strat.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_KT_Strat.cs
@@ -317,9 +317,11 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
         public float BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
         public bool ShowRoleOverlayText;
         public bool ShowTowerCountOverlay;
-        public bool ShowActionHint;
-        public bool ShowWaveAndDebuffHint;
-        public bool ShowHintOnKefka;
+        public bool ShowHintElement;
+        public bool HintOnYourHead = true;
+        public bool HintOnKefka;
+        public bool ShowGimmickHint;
+        public bool ShowYourTaskHint = true;
 
         public void EnsureDefaults()
         {
@@ -359,9 +361,11 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
             ShowRoleOverlayText = false;
             ShowTowerCountOverlay = false;
-            ShowActionHint = false;
-            ShowWaveAndDebuffHint = false;
-            ShowHintOnKefka = false;
+            ShowHintElement = false;
+            HintOnYourHead = true;
+            HintOnKefka = false;
+            ShowGimmickHint = false;
+            ShowYourTaskHint = true;
         }
 
         private static MarkerResolveKind ClampMarkerResolveKind(MarkerResolveKind kind)
@@ -635,9 +639,19 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             C.BaitAllThingsEndingRange = ClampBaitAllThingsEndingRange(range);
         ImGui.Checkbox("Show role overlay text on nav", ref C.ShowRoleOverlayText);
         ImGui.Checkbox("Show tower step overlay on Kefka", ref C.ShowTowerCountOverlay);
-        ImGui.Checkbox("Show Action Hint", ref C.ShowActionHint);
-        ImGui.Checkbox("Show Wave and Debuff Hint", ref C.ShowWaveAndDebuffHint);
-        ImGui.Checkbox("Show Hint on Kefka", ref C.ShowHintOnKefka);
+        ImGui.Checkbox("Show Hint Element", ref C.ShowHintElement);
+        ImGui.Indent();
+        ImGui.BeginDisabled(!C.ShowHintElement);
+        ImGui.TextDisabled("Hint Position");
+        ImGui.Checkbox("On Your Head", ref C.HintOnYourHead);
+        ImGui.Checkbox("On Kefka", ref C.HintOnKefka);
+        ImGui.TextDisabled("Hint Contents");
+        ImGui.Checkbox("Gimmick Hint", ref C.ShowGimmickHint);
+        ImGui.Checkbox("Your Task Hint", ref C.ShowYourTaskHint);
+        ImGui.SameLine();
+        ImGuiEx.HelpMarker("e.g. Right-Tower Back, Left-Tower Bait Cone");
+        ImGui.EndDisabled();
+        ImGui.Unindent();
     }
 
     // Clamp and snap bait range to 0.5 steps within 5~15.
@@ -1541,63 +1555,69 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
         }
     }
 
-    // Update Hint overlay from Hints layout; show on self or Kefka by config.
+    // Always build Gimmick/Task hint text for Attention Window; overlay uses Show Hint Element.
     private void UpdateHint()
     {
         C.EnsureDefaults();
-        if(!C.ShowActionHint && !C.ShowWaveAndDebuffHint)
-        {
-            DisableHint();
-            return;
-        }
 
-        string? waveLine = null;
+        var waveLine = BuildWaveAndDebuffHintText();
         string? actionLine = null;
-
-        if(C.ShowWaveAndDebuffHint)
-            waveLine = BuildWaveAndDebuffHintText();
-
-        if(C.ShowActionHint && !IsPatternPreviewActive())
+        if(!IsPatternPreviewActive())
         {
             var key = ResolveActionHintKey();
             if(key != null)
                 actionLine = GetHintText(key);
         }
 
-        if(string.IsNullOrEmpty(waveLine) && string.IsNullOrEmpty(actionLine))
+        var attentionText = CombineHintLines(waveLine, actionLine);
+        if(!string.IsNullOrEmpty(attentionText))
+            DisplayHintInAttentionWindow(attentionText);
+
+        if(!C.ShowHintElement || (!C.ShowGimmickHint && !C.ShowYourTaskHint))
         {
             DisableHint();
             return;
         }
 
-        var text = !string.IsNullOrEmpty(waveLine) && !string.IsNullOrEmpty(actionLine)
-            ? $"{waveLine}\n{actionLine}"
-            : waveLine ?? actionLine ?? "";
+        var elementWave = C.ShowGimmickHint ? waveLine : null;
+        var elementAction = C.ShowYourTaskHint ? actionLine : null;
+        var elementText = CombineHintLines(elementWave, elementAction);
+        if(string.IsNullOrEmpty(elementText))
+        {
+            DisableHint();
+            return;
+        }
 
-        ApplyHintText(text);
-        DisplayHintInAttentionWindow(text);
+        ApplyHintText(elementText);
     }
 
-    // Apply hint text to self or Kefka element based on ShowHintOnKefka.
+    // Join non-empty hint lines with newline.
+    private static string CombineHintLines(string? waveLine, string? actionLine)
+    {
+        if(!string.IsNullOrEmpty(waveLine) && !string.IsNullOrEmpty(actionLine))
+            return $"{waveLine}\n{actionLine}";
+        return waveLine ?? actionLine ?? "";
+    }
+
+    // Apply hint text to self and/or Kefka elements based on Hint Position config.
     private void ApplyHintText(string text)
     {
-        var onKefka = C.ShowHintOnKefka;
         if(Controller.TryGetElementByName(ElHint, out var hintSelf))
         {
-            if(onKefka)
-            {
-                hintSelf.Enabled = false;
-            }
-            else
+            if(C.HintOnYourHead)
             {
                 hintSelf.overlayText = text;
                 hintSelf.Enabled = true;
+            }
+            else
+            {
+                hintSelf.Enabled = false;
             }
         }
 
         if(Controller.TryGetElementByName(ElHintKefka, out var hintKefka))
         {
-            if(onKefka)
+            if(C.HintOnKefka)
             {
                 hintKefka.overlayText = text;
                 hintKefka.Enabled = true;

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_KT_Strat.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_1238_4567_KT_Strat.cs
@@ -27,7 +27,7 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
 {
     #region Metadata
 
-    public override Metadata? Metadata => new(7, "mirage");
+    public override Metadata? Metadata => new(8, "mirage");
     public override HashSet<uint>? ValidTerritories => [TerritoryDmad];
 
     #endregion
@@ -130,6 +130,15 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
     private const string ElActiveTower1 = "ActiveTower1";
     private const string ElTowerCount = "tower_count";
     private const string ElMyRole = "MyRole";
+    private const string ElHint = "Hint";
+    private const string ElHintKefka = "HintKefka";
+    private const string LayoutHints = "Hints";
+
+    private const string HintWaveAndDebuff = "Wave_and_Debuff";
+    private const string HintBaitAllThingsEndingWithFuture = "Bait_AllThingsEnding_with_Future";
+    private const string HintBaitAllThingsEndingWithPast = "Bait_AllThingsEnding_with_Past";
+    private const string HintFinalAllThingsEndingWithFuture = "Final_AllThingsEnding_with_Future";
+    private const string HintFinalAllThingsEndingWithPast = "Final_AllThingsEnding_with_Past";
 
     private static readonly string[] BasisComboLabels = ["LeftTower", "RightTower", "Center"];
 
@@ -308,6 +317,9 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
         public float BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
         public bool ShowRoleOverlayText;
         public bool ShowTowerCountOverlay;
+        public bool ShowActionHint;
+        public bool ShowWaveAndDebuffHint;
+        public bool ShowHintOnKefka;
 
         public void EnsureDefaults()
         {
@@ -347,6 +359,9 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
             ShowRoleOverlayText = false;
             ShowTowerCountOverlay = false;
+            ShowActionHint = false;
+            ShowWaveAndDebuffHint = false;
+            ShowHintOnKefka = false;
         }
 
         private static MarkerResolveKind ClampMarkerResolveKind(MarkerResolveKind kind)
@@ -426,6 +441,16 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             fillIntensity = 0.544f,
             tether = true,
         });
+
+        Controller.RegisterElementFromCode(ElHint,
+            """{"Name":"","type":1,"radius":0.0,"Filled":false,"fillIntensity":0.5,"thicc":0.0,"overlayVOffset":3.0,"overlayFScale":2.0,"overlayText":"Hint","refActorType":1}""",
+            overwrite: true);
+        Controller.RegisterElementFromCode(ElHintKefka,
+            """{"Name":"","type":1,"radius":0.0,"Filled":false,"fillIntensity":0.5,"thicc":0.0,"overlayVOffset":3.0,"overlayFScale":2.0,"overlayText":"Hint","refActorDataID":19506,"refActorComparisonType":3}""",
+            overwrite: true);
+        Controller.TryRegisterLayoutFromCode(LayoutHints, """
+            ~Lv2~{"Enabled":false,"Name":"Hints","ZoneLockH":[1363],"ElementsL":[{"Name":"211_LeftStack","overlayText":"Left-Tower Front","overlayTextIntl":{"Jp":"左塔の前"}},{"Name":"211_Cone","overlayText":"Left-Tower Back","overlayTextIntl":{"Jp":"左塔の後"}},{"Name":"211_RightStack","overlayText":"Right-Tower Front","overlayTextIntl":{"Jp":"右塔の前"}},{"Name":"211_Spread","overlayText":"Right-Tower Back","overlayTextIntl":{"Jp":"右塔の後"}},{"Name":"211_Tank","overlayText":"Left-Tower Stack Support","overlayTextIntl":{"Jp":"左塔の外で頭割り"}},{"Name":"211_Healer","overlayText":"Left-Tower Bait Cone","overlayTextIntl":{"Jp":"左塔の外で扇誘導"}},{"Name":"211_Melee","overlayText":"Right-Tower Stack Support","overlayTextIntl":{"Jp":"右塔の外で頭割り"}},{"Name":"211_Range","overlayText":"Right-Tower Stack Support","overlayTextIntl":{"Jp":"右塔の外で頭割り"}},{"Name":"022_LeftCone","overlayText":"Left-Tower Front","overlayTextIntl":{"Jp":"左塔の前"}},{"Name":"022_LeftSpread","overlayText":"Left-Tower Back","overlayTextIntl":{"Jp":"左塔の後"}},{"Name":"022_RightCone","overlayText":"Right-Tower Front","overlayTextIntl":{"Jp":"右塔の前"}},{"Name":"022_RightSpread","overlayText":"Right-Tower Back","overlayTextIntl":{"Jp":"右塔の後"}},{"Name":"022_Tank","overlayText":"Bait AllThingEnding","overlayTextIntl":{"Jp":"終焉誘導"}},{"Name":"022_Healer","overlayText":"Left-Tower Bait Cone","overlayTextIntl":{"Jp":"左塔の外で扇誘導"}},{"Name":"022_Melee","overlayText":"Bait AllThingEnding","overlayTextIntl":{"Jp":"終焉誘導"}},{"Name":"022_Range","overlayText":"Right-Tower Bait Cone","overlayTextIntl":{"Jp":"右塔の外で扇誘導"}},{"Name":"Bait_AllThingsEnding_with_Future","overlayText":"Go Opposite Tower","overlayTextIntl":{"Jp":"塔の反対側へ"}},{"Name":"Bait_AllThingsEnding_with_Past","overlayText":"Go Between Tower","overlayTextIntl":{"Jp":"塔の間へ"}},{"Name":"Final_AllThingsEnding_with_Future","overlayText":"Go North and Go Opposite","overlayTextIntl":{"Jp":"北へ行き詠唱完了で反対側へ"}},{"Name":"Final_AllThingsEnding_with_Past","overlayText":"Go North and Stay","overlayTextIntl":{"Jp":"北へ行きそのまま動かない"}},{"Name":"Wave_and_Debuff","overlayText":"Wave: {0}, Debuff: {1}","overlayTextIntl":{"Jp":"塔{0}回目  デバフ:{1}"}},{"Name":"Stack","overlayText":"Stack","overlayTextIntl":{"Jp":"頭割り"}},{"Name":"Spread","overlayText":"Spread","overlayTextIntl":{"Jp":"散開"}},{"Name":"Cone","overlayText":"Cone","overlayTextIntl":{"Jp":"扇"}},{"Name":"None","overlayText":"None","overlayTextIntl":{"Jp":"なし"}}]}
+            """, out _, overwrite: true);
     }
 
     public override void OnUpdate()
@@ -443,6 +468,7 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
         TryRunStep4AutoMark();
         LogStep4AutoMarkSkipOnce();
         UpdateFieldMarkers();
+        UpdateHint();
     }
 
     public override void OnReset()
@@ -609,6 +635,9 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             C.BaitAllThingsEndingRange = ClampBaitAllThingsEndingRange(range);
         ImGui.Checkbox("Show role overlay text on nav", ref C.ShowRoleOverlayText);
         ImGui.Checkbox("Show tower step overlay on Kefka", ref C.ShowTowerCountOverlay);
+        ImGui.Checkbox("Show Action Hint", ref C.ShowActionHint);
+        ImGui.Checkbox("Show Wave and Debuff Hint", ref C.ShowWaveAndDebuffHint);
+        ImGui.Checkbox("Show Hint on Kefka", ref C.ShowHintOnKefka);
     }
 
     // Clamp and snap bait range to 0.5 steps within 5~15.
@@ -1426,6 +1455,7 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             towerCount.Enabled = false;
         DisableAllRolePreviewMarkers();
         DisableMyRoleMarker();
+        DisableHint();
     }
 
     #endregion
@@ -1509,6 +1539,166 @@ internal class P2_Missing_1238_4567_KT_Strat : SplatoonScript
             element.Enabled = false;
             element.tether = false;
         }
+    }
+
+    // Update Hint overlay from Hints layout; show on self or Kefka by config.
+    private void UpdateHint()
+    {
+        C.EnsureDefaults();
+        if(!C.ShowActionHint && !C.ShowWaveAndDebuffHint)
+        {
+            DisableHint();
+            return;
+        }
+
+        string? waveLine = null;
+        string? actionLine = null;
+
+        if(C.ShowWaveAndDebuffHint)
+            waveLine = BuildWaveAndDebuffHintText();
+
+        if(C.ShowActionHint && !IsPatternPreviewActive())
+        {
+            var key = ResolveActionHintKey();
+            if(key != null)
+                actionLine = GetHintText(key);
+        }
+
+        if(string.IsNullOrEmpty(waveLine) && string.IsNullOrEmpty(actionLine))
+        {
+            DisableHint();
+            return;
+        }
+
+        var text = !string.IsNullOrEmpty(waveLine) && !string.IsNullOrEmpty(actionLine)
+            ? $"{waveLine}\n{actionLine}"
+            : waveLine ?? actionLine ?? "";
+
+        ApplyHintText(text);
+        DisplayHintInAttentionWindow(text);
+    }
+
+    // Apply hint text to self or Kefka element based on ShowHintOnKefka.
+    private void ApplyHintText(string text)
+    {
+        var onKefka = C.ShowHintOnKefka;
+        if(Controller.TryGetElementByName(ElHint, out var hintSelf))
+        {
+            if(onKefka)
+            {
+                hintSelf.Enabled = false;
+            }
+            else
+            {
+                hintSelf.overlayText = text;
+                hintSelf.Enabled = true;
+            }
+        }
+
+        if(Controller.TryGetElementByName(ElHintKefka, out var hintKefka))
+        {
+            if(onKefka)
+            {
+                hintKefka.overlayText = text;
+                hintKefka.Enabled = true;
+            }
+            else
+            {
+                hintKefka.Enabled = false;
+            }
+        }
+    }
+
+    // Keep Attention Window open with current hint lines (Splatoon can disable per script).
+    private void DisplayHintInAttentionWindow(string text)
+    {
+        if(string.IsNullOrEmpty(text))
+            return;
+
+        foreach(var line in text.Split('\n'))
+        {
+            if(!string.IsNullOrEmpty(line))
+                Controller.DisplayAttentionWindowLine(line);
+        }
+    }
+
+    // Build Wave/Debuff hint line from Hints layout templates.
+    private string? BuildWaveAndDebuffHintText()
+    {
+        if(!_hasActiveTowers || _step is < ActiveStepMin or > ActiveStepMax)
+            return null;
+        if(BasePlayer == null)
+            return null;
+
+        var template = GetHintText(HintWaveAndDebuff);
+        if(string.IsNullOrEmpty(template))
+            return null;
+
+        var debuffKind = GetDebuffKind(BasePlayer);
+        var debuffText = GetHintText(debuffKind.ToString()) ?? debuffKind.ToString();
+        return string.Format(template, _step, debuffText);
+    }
+
+    // Resolve Action Hint key from interlude phase or live role label.
+    private string? ResolveActionHintKey()
+    {
+        if(TryGetInterludeNavPosition(out _, out _))
+        {
+            var isPast = _interludeNavPhase == InterludeNavPhase.PastGap;
+            if(_step == ActiveStepMax)
+                return isPast ? HintFinalAllThingsEndingWithPast : HintFinalAllThingsEndingWithFuture;
+            return isPast ? HintBaitAllThingsEndingWithPast : HintBaitAllThingsEndingWithFuture;
+        }
+
+        if(!_hasActiveTowers || _step is < ActiveStepMin or > ActiveStepMax)
+            return null;
+        if(!TryUpdateLiveRoles(out _, out var roleLabel))
+            return null;
+
+        return MapRoleLabelToHintKey(roleLabel);
+    }
+
+    // Map Strat RoleLabel names to shared Hints layout element names.
+    private static string? MapRoleLabelToHintKey(string roleLabel)
+        => roleLabel switch
+        {
+            "211_StackPriority1" => "211_LeftStack",
+            "211_StackPriority2" => "211_RightStack",
+            "211_Cone" => "211_Cone",
+            "211_Spread" => "211_Spread",
+            "211_NotTowerPriority1" => "211_Healer",
+            "211_NotTowerPriority2" => "211_Tank",
+            "211_NotTowerPriority3" => "211_Melee",
+            "211_NotTowerPriority4" => "211_Range",
+            "022_ConePriority1" => "022_LeftCone",
+            "022_ConePriority2" => "022_RightCone",
+            "022_SpreadPriority1" => "022_LeftSpread",
+            "022_SpreadPriority2" => "022_RightSpread",
+            "022_DemisePriority1" => "022_Healer",
+            "022_DemisePriority2" => "022_Tank",
+            "022_DemisePriority3" => "022_Melee",
+            "022_DemisePriority4" => "022_Range",
+            _ => null,
+        };
+
+    // Read localized overlayText from Hints layout by element name.
+    private string? GetHintText(string key)
+    {
+        var source = Controller.GetRegisteredLayouts().SafeSelect(LayoutHints)?.GetElement(key);
+        if(source == null)
+            return null;
+
+        var text = source.overlayTextIntl.Get(source.overlayText);
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
+    // Turns the display Hint elements off.
+    private void DisableHint()
+    {
+        if(Controller.TryGetElementByName(ElHint, out var hint))
+            hint.Enabled = false;
+        if(Controller.TryGetElementByName(ElHintKefka, out var hintKefka))
+            hintKefka.Enabled = false;
     }
 
     private void UpdatePatternPreviewMarkers()

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_KT_Alt.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_KT_Alt.cs
@@ -225,9 +225,11 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
         public float BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
         public bool ShowRoleOverlayText;
         public bool ShowTowerCountOverlay;
-        public bool ShowActionHint;
-        public bool ShowWaveAndDebuffHint;
-        public bool ShowHintOnKefka;
+        public bool ShowHintElement;
+        public bool HintOnYourHead = true;
+        public bool HintOnKefka;
+        public bool ShowGimmickHint;
+        public bool ShowYourTaskHint = true;
 
         public void EnsureDefaults()
         {
@@ -279,9 +281,11 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
             BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
             ShowRoleOverlayText = false;
             ShowTowerCountOverlay = false;
-            ShowActionHint = false;
-            ShowWaveAndDebuffHint = false;
-            ShowHintOnKefka = false;
+            ShowHintElement = false;
+            HintOnYourHead = true;
+            HintOnKefka = false;
+            ShowGimmickHint = false;
+            ShowYourTaskHint = true;
         }
 
         private static Wave8MarkerSlot ClampWave8MarkerSlot(Wave8MarkerSlot slot)
@@ -2332,63 +2336,69 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
             towerCount.Enabled = false;
     }
 
-    // Update Hint overlay from Hints layout; show on self or Kefka by config.
+    // Always build Gimmick/Task hint text for Attention Window; overlay uses Show Hint Element.
     private void UpdateHint()
     {
         C.EnsureDefaults();
-        if(!C.ShowActionHint && !C.ShowWaveAndDebuffHint)
-        {
-            DisableHint();
-            return;
-        }
 
-        string? waveLine = null;
+        var waveLine = BuildWaveAndDebuffHintText();
         string? actionLine = null;
-
-        if(C.ShowWaveAndDebuffHint)
-            waveLine = BuildWaveAndDebuffHintText();
-
-        if(C.ShowActionHint && !IsPatternPreviewActive())
+        if(!IsPatternPreviewActive())
         {
             var key = ResolveActionHintKey();
             if(key != null)
                 actionLine = GetHintText(key);
         }
 
-        if(string.IsNullOrEmpty(waveLine) && string.IsNullOrEmpty(actionLine))
+        var attentionText = CombineHintLines(waveLine, actionLine);
+        if(!string.IsNullOrEmpty(attentionText))
+            DisplayHintInAttentionWindow(attentionText);
+
+        if(!C.ShowHintElement || (!C.ShowGimmickHint && !C.ShowYourTaskHint))
         {
             DisableHint();
             return;
         }
 
-        var text = !string.IsNullOrEmpty(waveLine) && !string.IsNullOrEmpty(actionLine)
-            ? $"{waveLine}\n{actionLine}"
-            : waveLine ?? actionLine ?? "";
+        var elementWave = C.ShowGimmickHint ? waveLine : null;
+        var elementAction = C.ShowYourTaskHint ? actionLine : null;
+        var elementText = CombineHintLines(elementWave, elementAction);
+        if(string.IsNullOrEmpty(elementText))
+        {
+            DisableHint();
+            return;
+        }
 
-        ApplyHintText(text);
-        DisplayHintInAttentionWindow(text);
+        ApplyHintText(elementText);
     }
 
-    // Apply hint text to self or Kefka element based on ShowHintOnKefka.
+    // Join non-empty hint lines with newline.
+    private static string CombineHintLines(string? waveLine, string? actionLine)
+    {
+        if(!string.IsNullOrEmpty(waveLine) && !string.IsNullOrEmpty(actionLine))
+            return $"{waveLine}\n{actionLine}";
+        return waveLine ?? actionLine ?? "";
+    }
+
+    // Apply hint text to self and/or Kefka elements based on Hint Position config.
     private void ApplyHintText(string text)
     {
-        var onKefka = C.ShowHintOnKefka;
         if(Controller.TryGetElementByName(ElHint, out var hintSelf))
         {
-            if(onKefka)
-            {
-                hintSelf.Enabled = false;
-            }
-            else
+            if(C.HintOnYourHead)
             {
                 hintSelf.overlayText = text;
                 hintSelf.Enabled = true;
+            }
+            else
+            {
+                hintSelf.Enabled = false;
             }
         }
 
         if(Controller.TryGetElementByName(ElHintKefka, out var hintKefka))
         {
-            if(onKefka)
+            if(C.HintOnKefka)
             {
                 hintKefka.overlayText = text;
                 hintKefka.Enabled = true;
@@ -2965,9 +2975,19 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
             C.BaitAllThingsEndingRange = ClampBaitAllThingsEndingRange(range);
         ImGui.Checkbox("Show role overlay text on nav", ref C.ShowRoleOverlayText);
         ImGui.Checkbox("Show tower step overlay on Kefka", ref C.ShowTowerCountOverlay);
-        ImGui.Checkbox("Show Action Hint", ref C.ShowActionHint);
-        ImGui.Checkbox("Show Wave and Debuff Hint", ref C.ShowWaveAndDebuffHint);
-        ImGui.Checkbox("Show Hint on Kefka", ref C.ShowHintOnKefka);
+        ImGui.Checkbox("Show Hint Element", ref C.ShowHintElement);
+        ImGui.Indent();
+        ImGui.BeginDisabled(!C.ShowHintElement);
+        ImGui.TextDisabled("Hint Position");
+        ImGui.Checkbox("On Your Head", ref C.HintOnYourHead);
+        ImGui.Checkbox("On Kefka", ref C.HintOnKefka);
+        ImGui.TextDisabled("Hint Contents");
+        ImGui.Checkbox("Gimmick Hint", ref C.ShowGimmickHint);
+        ImGui.Checkbox("Your Task Hint", ref C.ShowYourTaskHint);
+        ImGui.SameLine();
+        ImGuiEx.HelpMarker("e.g. Right-Tower Back, Left-Tower Bait Cone");
+        ImGui.EndDisabled();
+        ImGui.Unindent();
     }
 
     // Clamp and snap bait range to 0.5 steps within 5~15.

--- a/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_KT_Alt.cs
+++ b/SplatoonScripts/Duties/Dawntrail/Dancing Mad/P2_Forsaken_Pattern/P2_Missing_KT_Alt.cs
@@ -28,7 +28,7 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
 {
     #region Metadata
 
-    public override Metadata Metadata { get; } = new(7, "mirage");
+    public override Metadata Metadata { get; } = new(8, "mirage");
     public override HashSet<uint>? ValidTerritories => [TerritoryDmad];
 
     #endregion
@@ -118,6 +118,15 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
     private const string ElTowerCount = "tower_count";
     private const string ElMyRole = "MyRole";
     private const string ElMyRoleAlt = "MyRoleAlt";
+    private const string ElHint = "Hint";
+    private const string ElHintKefka = "HintKefka";
+    private const string LayoutHints = "Hints";
+
+    private const string HintWaveAndDebuff = "Wave_and_Debuff";
+    private const string HintBaitAllThingsEndingWithFuture = "Bait_AllThingsEnding_with_Future";
+    private const string HintBaitAllThingsEndingWithPast = "Bait_AllThingsEnding_with_Past";
+    private const string HintFinalAllThingsEndingWithFuture = "Final_AllThingsEnding_with_Future";
+    private const string HintFinalAllThingsEndingWithPast = "Final_AllThingsEnding_with_Past";
 
     private const string Role211LeftStack = "211_LeftStack";
     private const string Role211Cone = "211_Cone";
@@ -216,6 +225,9 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
         public float BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
         public bool ShowRoleOverlayText;
         public bool ShowTowerCountOverlay;
+        public bool ShowActionHint;
+        public bool ShowWaveAndDebuffHint;
+        public bool ShowHintOnKefka;
 
         public void EnsureDefaults()
         {
@@ -267,6 +279,9 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
             BaitAllThingsEndingRange = DefaultBaitAllThingsEndingRange;
             ShowRoleOverlayText = false;
             ShowTowerCountOverlay = false;
+            ShowActionHint = false;
+            ShowWaveAndDebuffHint = false;
+            ShowHintOnKefka = false;
         }
 
         private static Wave8MarkerSlot ClampWave8MarkerSlot(Wave8MarkerSlot slot)
@@ -470,6 +485,16 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
                 """{"Enabled":false,"radius":0.25,"Donut":0.1,"fillIntensity":0.544,"tether":false}""",
                 overwrite: true);
         }
+
+        Controller.RegisterElementFromCode(ElHint,
+            """{"Name":"","type":1,"radius":0.0,"Filled":false,"fillIntensity":0.5,"thicc":0.0,"overlayVOffset":3.0,"overlayFScale":2.0,"overlayText":"Hint","refActorType":1}""",
+            overwrite: true);
+        Controller.RegisterElementFromCode(ElHintKefka,
+            """{"Name":"","type":1,"radius":0.0,"Filled":false,"fillIntensity":0.5,"thicc":0.0,"overlayVOffset":3.0,"overlayFScale":2.0,"overlayText":"Hint","refActorDataID":19506,"refActorComparisonType":3}""",
+            overwrite: true);
+        Controller.TryRegisterLayoutFromCode(LayoutHints, """
+            ~Lv2~{"Enabled":false,"Name":"Hints","ZoneLockH":[1363],"ElementsL":[{"Name":"211_LeftStack","overlayText":"Left-Tower Front","overlayTextIntl":{"Jp":"左塔の前"}},{"Name":"211_Cone","overlayText":"Left-Tower Back","overlayTextIntl":{"Jp":"左塔の後"}},{"Name":"211_RightStack","overlayText":"Right-Tower Front","overlayTextIntl":{"Jp":"右塔の前"}},{"Name":"211_Spread","overlayText":"Right-Tower Back","overlayTextIntl":{"Jp":"右塔の後"}},{"Name":"211_Tank","overlayText":"Left-Tower Stack Support","overlayTextIntl":{"Jp":"左塔の外で頭割り"}},{"Name":"211_Healer","overlayText":"Left-Tower Bait Cone","overlayTextIntl":{"Jp":"左塔の外で扇誘導"}},{"Name":"211_Melee","overlayText":"Right-Tower Stack Support","overlayTextIntl":{"Jp":"右塔の外で頭割り"}},{"Name":"211_Range","overlayText":"Right-Tower Stack Support","overlayTextIntl":{"Jp":"右塔の外で頭割り"}},{"Name":"022_LeftCone","overlayText":"Left-Tower Front","overlayTextIntl":{"Jp":"左塔の前"}},{"Name":"022_LeftSpread","overlayText":"Left-Tower Back","overlayTextIntl":{"Jp":"左塔の後"}},{"Name":"022_RightCone","overlayText":"Right-Tower Front","overlayTextIntl":{"Jp":"右塔の前"}},{"Name":"022_RightSpread","overlayText":"Right-Tower Back","overlayTextIntl":{"Jp":"右塔の後"}},{"Name":"022_Tank","overlayText":"Bait AllThingEnding","overlayTextIntl":{"Jp":"終焉誘導"}},{"Name":"022_Healer","overlayText":"Left-Tower Bait Cone","overlayTextIntl":{"Jp":"左塔の外で扇誘導"}},{"Name":"022_Melee","overlayText":"Bait AllThingEnding","overlayTextIntl":{"Jp":"終焉誘導"}},{"Name":"022_Range","overlayText":"Right-Tower Bait Cone","overlayTextIntl":{"Jp":"右塔の外で扇誘導"}},{"Name":"Bait_AllThingsEnding_with_Future","overlayText":"Go Opposite Tower","overlayTextIntl":{"Jp":"塔の反対側へ"}},{"Name":"Bait_AllThingsEnding_with_Past","overlayText":"Go Between Tower","overlayTextIntl":{"Jp":"塔の間へ"}},{"Name":"Final_AllThingsEnding_with_Future","overlayText":"Go North and Go Opposite","overlayTextIntl":{"Jp":"北へ行き詠唱完了で反対側へ"}},{"Name":"Final_AllThingsEnding_with_Past","overlayText":"Go North and Stay","overlayTextIntl":{"Jp":"北へ行きそのまま動かない"}},{"Name":"Wave_and_Debuff","overlayText":"Wave: {0}, Debuff: {1}","overlayTextIntl":{"Jp":"塔{0}回目  デバフ:{1}"}},{"Name":"Stack","overlayText":"Stack","overlayTextIntl":{"Jp":"頭割り"}},{"Name":"Spread","overlayText":"Spread","overlayTextIntl":{"Jp":"散開"}},{"Name":"Cone","overlayText":"Cone","overlayTextIntl":{"Jp":"扇"}},{"Name":"None","overlayText":"None","overlayTextIntl":{"Jp":"なし"}}]}
+            """, out _, overwrite: true);
     }
 
     public override void OnUpdate()
@@ -487,6 +512,7 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
         TryRunStep4DebuffReminder();
         LogStep4DebuffReminderSkipOnce();
         UpdateFieldMarkers();
+        UpdateHint();
     }
 
     public override void OnReset()
@@ -2297,12 +2323,154 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
     {
         DisableMyRoleMarkers();
         DisableAllRolePreviewMarkers();
+        DisableHint();
         if(Controller.TryGetElementByName(ElActiveTower0, out var tower0))
             tower0.Enabled = false;
         if(Controller.TryGetElementByName(ElActiveTower1, out var tower1))
             tower1.Enabled = false;
         if(Controller.TryGetElementByName(ElTowerCount, out var towerCount))
             towerCount.Enabled = false;
+    }
+
+    // Update Hint overlay from Hints layout; show on self or Kefka by config.
+    private void UpdateHint()
+    {
+        C.EnsureDefaults();
+        if(!C.ShowActionHint && !C.ShowWaveAndDebuffHint)
+        {
+            DisableHint();
+            return;
+        }
+
+        string? waveLine = null;
+        string? actionLine = null;
+
+        if(C.ShowWaveAndDebuffHint)
+            waveLine = BuildWaveAndDebuffHintText();
+
+        if(C.ShowActionHint && !IsPatternPreviewActive())
+        {
+            var key = ResolveActionHintKey();
+            if(key != null)
+                actionLine = GetHintText(key);
+        }
+
+        if(string.IsNullOrEmpty(waveLine) && string.IsNullOrEmpty(actionLine))
+        {
+            DisableHint();
+            return;
+        }
+
+        var text = !string.IsNullOrEmpty(waveLine) && !string.IsNullOrEmpty(actionLine)
+            ? $"{waveLine}\n{actionLine}"
+            : waveLine ?? actionLine ?? "";
+
+        ApplyHintText(text);
+        DisplayHintInAttentionWindow(text);
+    }
+
+    // Apply hint text to self or Kefka element based on ShowHintOnKefka.
+    private void ApplyHintText(string text)
+    {
+        var onKefka = C.ShowHintOnKefka;
+        if(Controller.TryGetElementByName(ElHint, out var hintSelf))
+        {
+            if(onKefka)
+            {
+                hintSelf.Enabled = false;
+            }
+            else
+            {
+                hintSelf.overlayText = text;
+                hintSelf.Enabled = true;
+            }
+        }
+
+        if(Controller.TryGetElementByName(ElHintKefka, out var hintKefka))
+        {
+            if(onKefka)
+            {
+                hintKefka.overlayText = text;
+                hintKefka.Enabled = true;
+            }
+            else
+            {
+                hintKefka.Enabled = false;
+            }
+        }
+    }
+
+    // Keep Attention Window open with current hint lines (Splatoon can disable per script).
+    private void DisplayHintInAttentionWindow(string text)
+    {
+        if(string.IsNullOrEmpty(text))
+            return;
+
+        foreach(var line in text.Split('\n'))
+        {
+            if(!string.IsNullOrEmpty(line))
+                Controller.DisplayAttentionWindowLine(line);
+        }
+    }
+
+    // Build Wave/Debuff hint line from Hints layout templates.
+    private string? BuildWaveAndDebuffHintText()
+    {
+        if(!_hasActiveTowers || _step is < ActiveStepMin or > ActiveStepMax)
+            return null;
+        if(BasePlayer == null)
+            return null;
+
+        var template = GetHintText(HintWaveAndDebuff);
+        if(string.IsNullOrEmpty(template))
+            return null;
+
+        var debuffKind = GetDebuffKind(BasePlayer);
+        var debuffText = GetHintText(debuffKind.ToString()) ?? debuffKind.ToString();
+        return string.Format(template, _step, debuffText);
+    }
+
+    // Resolve Action Hint key from interlude phase or live role label.
+    private string? ResolveActionHintKey()
+    {
+        if(TryGetInterludeNavPosition(out _, out _))
+        {
+            var isPast = _interludeNavPhase == InterludeNavPhase.PastGap;
+            if(_step == ActiveStepMax)
+                return isPast ? HintFinalAllThingsEndingWithPast : HintFinalAllThingsEndingWithFuture;
+            return isPast ? HintBaitAllThingsEndingWithPast : HintBaitAllThingsEndingWithFuture;
+        }
+
+        if(!_hasActiveTowers || _step is < ActiveStepMin or > ActiveStepMax)
+            return null;
+        if(!TryUpdateLiveRoles(out var roleLabel))
+            return null;
+
+        return MapRoleLabelToHintKey(roleLabel);
+    }
+
+    // Map live RoleLabel to Hints layout element name (identity for KT_Alt).
+    private static string? MapRoleLabelToHintKey(string roleLabel)
+        => roleLabel;
+
+    // Read localized overlayText from Hints layout by element name.
+    private string? GetHintText(string key)
+    {
+        var source = Controller.GetRegisteredLayouts().SafeSelect(LayoutHints)?.GetElement(key);
+        if(source == null)
+            return null;
+
+        var text = source.overlayTextIntl.Get(source.overlayText);
+        return string.IsNullOrEmpty(text) ? null : text;
+    }
+
+    // Turns the display Hint elements off.
+    private void DisableHint()
+    {
+        if(Controller.TryGetElementByName(ElHint, out var hint))
+            hint.Enabled = false;
+        if(Controller.TryGetElementByName(ElHintKefka, out var hintKefka))
+            hintKefka.Enabled = false;
     }
 
     // Reset runtime state on wipe or scene leave.
@@ -2797,6 +2965,9 @@ internal class P2_Misisng_KT_Alt : SplatoonScript
             C.BaitAllThingsEndingRange = ClampBaitAllThingsEndingRange(range);
         ImGui.Checkbox("Show role overlay text on nav", ref C.ShowRoleOverlayText);
         ImGui.Checkbox("Show tower step overlay on Kefka", ref C.ShowTowerCountOverlay);
+        ImGui.Checkbox("Show Action Hint", ref C.ShowActionHint);
+        ImGui.Checkbox("Show Wave and Debuff Hint", ref C.ShowWaveAndDebuffHint);
+        ImGui.Checkbox("Show Hint on Kefka", ref C.ShowHintOnKefka);
     }
 
     // Clamp and snap bait range to 0.5 steps within 5~15.


### PR DESCRIPTION
1. Show Hint Option on JP Forsaken Script (KT_ALt, KT_Strat)

Hint Position
- On Your Head
- On Kefka

Hint Contents
- Gimmick Hint (Wave, Debuff)
  - e.g. `Wave : 3, Debuff : Stack`
- Your Task Hint
  - e.g. `Right-Tower Back`, `Left-Tower Bait Cone `

Also, hints are always displayed in the Attention Window.

You can edit hint messages in the Hints Layout. ( like P4 Debuff Reminder )

----
2. fix forsaken invidial scripts document

Scripts other than `KT_Strat`, `KT_Alt`, and `Rinon` may not be usable, so I have removed them from the list to avoid confusion.